### PR TITLE
Explicit dhcp ranges that cover all known hosts

### DIFF
--- a/inventories/dev/group_vars/dhcp-dev
+++ b/inventories/dev/group_vars/dhcp-dev
@@ -10,6 +10,7 @@ dhcp_ranges: |-
   dhcp-range=set:k8s-masters,10.88.0.64,10.88.0.65,12h
   dhcp-range=set:k8s-workers,10.88.0.128,10.88.0.130,12h
   dhcp-range=set:k8s-storage,10.88.0.192,10.88.0.193,12h
+  dhcp-range=set:cumulus,10.88.0.197,10.88.0.198,12h
 
 # dhcp static hosts
 dhcp_static_hosts: |-
@@ -27,6 +28,8 @@ dhcp_static_hosts: |-
   dhcp-host=78:45:C4:82:45:79,10.88.0.130 # worker-2 - dell M630 @ chassis slot 15
   dhcp-host=78:45:C4:82:45:86,10.88.0.192 # storage-node-0 - dell M630 @ chassis slot 16
   dhcp-host=a0:36:9f:9d:a8:9a,10.88.0.193 # storage-node-1 - dell R620 @ port 33
+  dhcp-host=cc:37:ab:a9:23:16,10.88.0.197
+  dhcp-host=cc:37:ab:a9:23:f4,10.88.0.198
 
 # dhcp options
 dhcp_options: |-

--- a/inventories/dev/group_vars/dhcp-dev
+++ b/inventories/dev/group_vars/dhcp-dev
@@ -4,7 +4,12 @@ dhcp_listen_interfaces: |-
 
 # dhcp ranges
 dhcp_ranges: |-
-  dhcp-range=set:k8s,10.88.0.4,10.88.0.254,12h
+  dhcp-range=set:cfssl,10.88.0.8,10.88.0.8,12h
+  dhcp-range=set:gobgp,10.88.0.12,10.88.0.14,12h
+  dhcp-range=set:etcd,10.88.0.32,10.88.0.34,12h
+  dhcp-range=set:k8s-masters,10.88.0.64,10.88.0.65,12h
+  dhcp-range=set:k8s-workers,10.88.0.128,10.88.0.130,12h
+  dhcp-range=set:k8s-storage,10.88.0.192,10.88.0.193,12h
 
 # dhcp static hosts
 dhcp_static_hosts: |-


### PR DESCRIPTION
That would prevent dnsmasq from leasing addresses to hosts that it doesn't
know their mac addresses