### PR TITLE
Revised netapp network setup

### DIFF
--- a/inventories/group_vars/netapp-dev
+++ b/inventories/group_vars/netapp-dev
@@ -3,9 +3,11 @@ netapp_username: "admin"
 netapp_password: "{{vault_netapp_admin_pass}}"
 node_1: system-01
 node_2: system-02
-vlan_parent_interface: e0c
 vlan_id: "2000"
-vlan_port: e0c-2000
+vlan_parent_interface_1: e0c
+vlan_port_1: e0c-2000
+vlan_parent_interface_2: e0d
+vlan_port_2: e0d-2000
 default_mtu: "9000"
 
 # cfssl

--- a/roles/netapp/tasks/cfssl.yaml
+++ b/roles/netapp/tasks/cfssl.yaml
@@ -5,6 +5,7 @@
     aggr_list: "{{ cfssl_aggregate_list }}"
     allowed_protocols:
     - iscsi
+    ipspace: "{{ env }}_ipspace"
     hostname: "{{ inventory_hostname }}"
     username: "{{ netapp_username }}"
     password: "{{ netapp_password }}"
@@ -32,7 +33,7 @@
   na_ontap_interface:
     state: present
     interface_name: "{{ env }}_cfssl_data_lif_1"
-    home_port: "{{ vlan_port }}"
+    home_port: "{{ vlan_port_1 }}"
     home_node: "{{ node_1 }}"
     role: data
     protocols: iscsi
@@ -48,7 +49,7 @@
   na_ontap_interface:
     state: present
     interface_name: "{{ env }}_cfssl_data_lif_2"
-    home_port: "{{ vlan_port }}"
+    home_port: "{{ vlan_port_1 }}"
     home_node: "{{ node_2 }}"
     role: data
     protocols: iscsi

--- a/roles/netapp/tasks/core.yaml
+++ b/roles/netapp/tasks/core.yaml
@@ -1,19 +1,39 @@
-- name: create {{ env }} VLAN {{ vlan_id }} on {{ node_1 }}
+- name: create {{ env }} VLAN {{ vlan_id }} on {{ node_1 }} for {{ vlan_parent_interface_1 }}
   na_ontap_net_vlan:
     state: present
     vlanid: "{{ vlan_id }}"
     node: "{{ node_1 }}"
-    parent_interface: "{{ vlan_parent_interface }}"
+    parent_interface: "{{ vlan_parent_interface_1 }}"
     hostname: "{{ inventory_hostname }}"
     username: "{{ netapp_username }}"
     password: "{{ netapp_password }}"
 
-- name: create {{ env }} VLAN {{ vlan_id }} on {{ node_2 }}
+- name: create {{ env }} VLAN {{ vlan_id }} on {{ node_2 }} for {{ vlan_parent_interface_1 }}
   na_ontap_net_vlan:
     state: present
     vlanid: "{{ vlan_id }}"
     node: "{{ node_2 }}"
-    parent_interface: "{{ vlan_parent_interface }}"
+    parent_interface: "{{ vlan_parent_interface_1 }}"
+    hostname: "{{ inventory_hostname }}"
+    username: "{{ netapp_username }}"
+    password: "{{ netapp_password }}"
+
+- name: create {{ env }} VLAN {{ vlan_id }} on {{ node_1 }} for {{ vlan_parent_interface_2 }}
+  na_ontap_net_vlan:
+    state: present
+    vlanid: "{{ vlan_id }}"
+    node: "{{ node_1 }}"
+    parent_interface: "{{ vlan_parent_interface_2 }}"
+    hostname: "{{ inventory_hostname }}"
+    username: "{{ netapp_username }}"
+    password: "{{ netapp_password }}"
+
+- name: create {{ env }} VLAN {{ vlan_id }} on {{ node_2 }} for {{ vlan_parent_interface_2 }}
+  na_ontap_net_vlan:
+    state: present
+    vlanid: "{{ vlan_id }}"
+    node: "{{ node_2 }}"
+    parent_interface: "{{ vlan_parent_interface_2 }}"
     hostname: "{{ inventory_hostname }}"
     username: "{{ netapp_username }}"
     password: "{{ netapp_password }}"
@@ -28,22 +48,65 @@
     username: "{{ netapp_username }}"
     password: "{{ netapp_password }}"
 
-- name: Use jumbo frames (mtu>=9000) on {{ node_1 }} port {{ vlan_parent_interface }}
-  na_ontap_net_port:
+- name: Create {{ env }} dedicated ipspace
+  na_ontap_ipspace:
     state: present
-    mtu: "{{ default_mtu }}"
-    node: "{{ node_1 }}"
-    ports: "{{ vlan_parent_interface }}"
+    name: "{{ env }}_ipspace"
     hostname: "{{ inventory_hostname }}"
     username: "{{ netapp_username }}"
     password: "{{ netapp_password }}"
 
-- name: Use jumbo frames (mtu>=9000) on {{ node_2 }} port {{ vlan_parent_interface }}
+- name: Create {{ env }} broadcast domain
+  na_ontap_broadcast_domain:
+    state: present
+    name: "{{ env }}_domain"
+    mtu: "{{ default_mtu }}"
+    ipspace: "{{ env }}_ipspace"
+    ports:
+      - "{{ node_1 }}:{{ vlan_port_1 }}"
+      - "{{ node_1 }}:{{ vlan_port_2 }}"
+      - "{{ node_2 }}:{{ vlan_port_1 }}"
+      - "{{ node_2 }}:{{ vlan_port_2 }}"
+    hostname: "{{ inventory_hostname }}"
+    username: "{{ netapp_username }}"
+    password: "{{ netapp_password }}"
+
+- name: Use jumbo frames (mtu>=9000) on {{ node_1 }} port {{ vlan_parent_interface_1 }}
+  na_ontap_net_port:
+    state: present
+    mtu: "{{ default_mtu }}"
+    node: "{{ node_1 }}"
+    ports: "{{ vlan_parent_interface_1 }}"
+    hostname: "{{ inventory_hostname }}"
+    username: "{{ netapp_username }}"
+    password: "{{ netapp_password }}"
+
+- name: Use jumbo frames (mtu>=9000) on {{ node_2 }} port {{ vlan_parent_interface_1 }}
   na_ontap_net_port:
     state: present
     mtu: "{{ default_mtu }}"
     node: "{{ node_2 }}"
-    ports: "{{ vlan_parent_interface }}"
+    ports: "{{ vlan_parent_interface_1 }}"
+    hostname: "{{ inventory_hostname }}"
+    username: "{{ netapp_username }}"
+    password: "{{ netapp_password }}"
+
+- name: Use jumbo frames (mtu>=9000) on {{ node_1 }} port {{ vlan_parent_interface_2 }}
+  na_ontap_net_port:
+    state: present
+    mtu: "{{ default_mtu }}"
+    node: "{{ node_1 }}"
+    ports: "{{ vlan_parent_interface_2 }}"
+    hostname: "{{ inventory_hostname }}"
+    username: "{{ netapp_username }}"
+    password: "{{ netapp_password }}"
+
+- name: Use jumbo frames (mtu>=9000) on {{ node_2 }} port {{ vlan_parent_interface_2 }}
+  na_ontap_net_port:
+    state: present
+    mtu: "{{ default_mtu }}"
+    node: "{{ node_2 }}"
+    ports: "{{ vlan_parent_interface_2 }}"
     hostname: "{{ inventory_hostname }}"
     username: "{{ netapp_username }}"
     password: "{{ netapp_password }}"

--- a/roles/netapp/tasks/kube.yaml
+++ b/roles/netapp/tasks/kube.yaml
@@ -5,6 +5,7 @@
     aggr_list: "{{ kube_aggregate_list }}"
     allowed_protocols:
     - iscsi
+    ipspace: "{{ env }}_ipspace"
     hostname: "{{ inventory_hostname }}"
     username: "{{ netapp_username }}"
     password: "{{ netapp_password }}"
@@ -32,7 +33,7 @@
   na_ontap_interface:
     state: present
     interface_name: "{{ env }}_kube_data_lif_1"
-    home_port: "{{ vlan_port }}"
+    home_port: "{{ vlan_port_1 }}"
     home_node: "{{ node_1 }}"
     role: data
     protocols: iscsi
@@ -48,7 +49,7 @@
   na_ontap_interface:
     state: present
     interface_name: "{{ env }}_kube_data_lif_2"
-    home_port: "{{ vlan_port }}"
+    home_port: "{{ vlan_port_1 }}"
     home_node: "{{ node_2 }}"
     role: data
     protocols: iscsi
@@ -65,7 +66,7 @@
   na_ontap_interface:
     state: present
     interface_name: "{{ env }}_kube_mgmt_lif"
-    home_port: "{{ vlan_port }}"
+    home_port: "{{ vlan_port_1 }}"
     home_node: "{{ node_1 }}"
     role: data
     firewall_policy: mgmt


### PR DESCRIPTION
- Create dedicated ipspace and broadcast domain per env
- Add 2nd port on the netapp vlan (Netapp will operate as HA between controllers
  and on active-passive between ports on the same controller)
- Even though failover policies are not supported for iscsi services, if an
  interface fails it will only be able to migrate in the same ipspcae/broadcast
  domain, which now only contain environment specific interfaces
- Deploy the 2nd port for dev environment