### PR TITLE
Template cumulus network interfaces

### DIFF
--- a/inventories/hosts
+++ b/inventories/hosts
@@ -7,12 +7,36 @@ cumulus-2
 [cumulus-1:vars]
 hostname=mer-cumulus-1
 router_id=10.254.254.253
+clagd_backup_ip=10.254.254.254
+clagd_priority=1000
+vlan_2_address=10.254.254.253/30
+vlan_88_address=172.30.88.253/24
+vlan_89_address=172.30.89.253/24
+vlan_188_address=10.88.0.253/24
+vlan_189_address=10.89.0.253/24
+vlan_288_address=192.168.88.253/24
+vlan_289_address=192.168.89.253/24
+vlan_1000_address=10.10.50.253/24
+vlan_2000_address=10.20.50.253/24
 
 [cumulus-2]
 10.91.5.105
 [cumulus-2:vars]
 hostname=mer-cumulus-2
 router_id=10.254.254.254
+clagd_backup_ip=10.254.254.253
+# We need higher priority value than cumulus-1:
+# https://docs.cumulusnetworks.com/cumulus-linux-41/Layer-2/Multi-Chassis-Link-Aggregation-MLAG/
+clagd_priority=2000
+vlan_2_address=10.254.254.254/30
+vlan_88_address=172.30.88.254/24
+vlan_89_address=172.30.89.254/24
+vlan_188_address=10.88.0.254/24
+vlan_189_address=10.89.0.254/24
+vlan_288_address=192.168.88.254/24
+vlan_289_address=192.168.89.254/24
+vlan_1000_address=10.10.50.254/24
+vlan_2000_address=10.20.50.254/24
 
 [dhcp-dev:children]
 cumulus

--- a/roles/cumulus/handlers/main.yaml
+++ b/roles/cumulus/handlers/main.yaml
@@ -1,7 +1,16 @@
+- name: daemon-reload
+  systemd:
+    daemon_reload: yes
+
 - name: install ACL rules
   command:
     cmd: "cl-acltool -i"
-  become: true
+  become: yes
+
+- name: reload network interfaces
+  command:
+    cmd: "ifreload -a"
+  become: yes
 
 - name: restart frr
   service:
@@ -14,7 +23,3 @@
     name: node-exporter.service
     state: restarted
   become: yes
-
-- name: daemon-reload
-  systemd:
-    daemon_reload: yes

--- a/roles/cumulus/tasks/main.yaml
+++ b/roles/cumulus/tasks/main.yaml
@@ -62,3 +62,11 @@
     state: started
     enabled: yes
   tags: node-exporter
+
+- name: Copy network interfaces configuration
+  template:
+    src: network-interfaces.tmpl
+    dest: "/etc/network/interfaces"
+  notify:
+    - reload network interfaces
+  tags: network

--- a/roles/cumulus/templates/network-interfaces.tmpl
+++ b/roles/cumulus/templates/network-interfaces.tmpl
@@ -1,0 +1,231 @@
+# This file describes the network interfaces available on your system
+# and how to activate them. For more information, see interfaces(5).
+source /etc/network/interfaces.d/*.intf
+
+# The loopback network interface
+auto lo
+iface lo inet loopback
+
+# The primary network interface
+auto eth0
+iface eth0 inet dhcp
+    vrf mgmt
+
+auto dev
+iface dev
+    vrf-table auto
+
+auto mgmt
+iface mgmt
+    address 127.0.0.1/8
+    address ::1/128
+    vrf-table auto
+
+#PeerLink Bond interace
+auto swp1
+iface swp1
+    mtu 9216
+    link-speed 400000
+
+auto swp2
+iface swp2
+    mtu 9216
+    link-speed 400000
+
+#Link to Merit-Network-VPC
+auto swp3
+iface swp3
+     mtu 9216
+
+#Link to Merit-Network-VPC
+auto swp4
+iface swp4
+     mtu 9216
+
+#PROD - Link to Netapp Controller "A" ( No Bond interface is supported by NetApp)
+auto swp5
+iface swp5
+    alias swp5 prod-netapp-ctrl-a
+    bridge-vids 1000
+    mtu 9216
+    link-autoneg on
+
+#DEV - Link to Netapp Controller "A" ( No Bond interface is supported by NetApp)
+auto swp6
+iface swp6
+    alias swp6 dev-netapp-ctrl-a
+    bridge-vids 2000
+    mtu 9216
+
+#PROD - Link to Netapp Controller "B" ( No Bond interface is supported by NetApp)
+auto swp28
+iface swp28
+    alias swp28 prod-netapp-ctrl-b
+    bridge-vids 1000
+    mtu 9216
+    link-autoneg on
+
+#DEV - Link to Netapp Controller "B" ( No Bond interface is supported by NetApp)
+auto swp29
+iface swp29
+    alias swp29 dev-netapp-ctrl-b
+    bridge-vids 2000
+    mtu 9216
+
+#Link to Moonshoot 1 (New one - DEV)
+auto swp30
+iface swp30
+    mtu 9216
+
+#Link to Moonshot 1 (New one - PROD)
+auto swp27
+iface swp27
+    link-down yes
+    mtu 9216
+
+#Link to Moonshoot 0 (Old one - DEV)
+auto swp31
+iface swp31
+    mtu 9216
+
+#PO to Merit-network-VPC
+auto bond-mer-mer
+iface bond-mer-mer
+    bond-slaves swp3 swp4
+    bridge-vids 1 88 89 288 289
+    mtu 9216
+    clag-id 4
+
+#PO to Moonshoot DEV (new one) - One iface per SW in MLAG
+auto bond-hp-m1-dev
+iface bond-hp-m1-dev
+    bond-slaves swp30
+    bridge-vids 188 189
+    clag-id 30
+    mtu 9216
+
+#PO to Moonshoot PROD (new one) - One iface per SW in MLAG
+auto bond-hp-m1-prod
+iface bond-hp-m1-prod
+    bond-slaves swp27
+    bridge-vids 189
+    clag-id 27
+    mtu 9216
+
+#PO to Moonshoot DEV (Old one) - One iface per SW in MLAG
+auto bond-hp-m0-dev
+iface bond-hp-m0-dev
+    bond-slaves swp31
+    bridge-vids 188 189
+    clag-id 31
+    mtu 9216
+
+#Brigde interface (All L2 Interfaces)
+auto bridge
+iface bridge
+    bridge-ports peerlink bond-hp-m0-dev bond-hp-m1-dev bond-hp-m1-prod bond-mer-mer swp5 swp6 swp28 swp29
+    bridge-vids 2 88 89 188 189 288 289 1000 2000
+    bridge-vlan-aware yes
+    mstpctl-treeprio 8192
+    mtu 9216
+
+#PeerLink bond for MLAG setup
+auto peerlink
+iface peerlink
+    bond-slaves swp1 swp2
+    mtu 9216
+
+auto peerlink.4094
+iface peerlink.4094
+    clagd-peer-ip linklocal
+    clagd-backup-ip {{ clagd_backup_ip }}
+    clagd-priority {{ clagd_priority }}
+    clagd-sys-mac 44:38:39:FF:01:01
+
+auto prod
+iface prod
+    vrf-table auto
+
+#This is an standard vlan created for CLAG-Backup LINK
+auto vlan2
+iface vlan2
+   address {{ vlan_2_address }}
+   vlan-id 2
+   vlan-raw-device bridge
+   mtu 9216
+
+#DEV- VLAN in use to PEER with Main Network - VRF internal
+auto vlan88
+iface vlan88
+    address {{ vlan_88_address }}
+    vlan-id 88
+    vlan-raw-device bridge
+    vrf dev
+    mtu 9216
+
+#PROD- VLAN in use to PEER with Main Network - VRF internal
+auto vlan89
+iface vlan89
+    address {{ vlan_89_address }}
+    vlan-id 89
+    vlan-raw-device bridge
+    vrf prod
+    mtu 9216
+
+#DEV Internal VLAN - where the nodes live
+auto vlan188
+iface vlan188
+    address {{ vlan_188_address }}
+    address-virtual 00:00:5E:00:01:01 10.88.0.1/24
+    vlan-id 188
+    vlan-raw-device bridge
+    vrf dev
+    mtu 9216
+
+#PROD Internal VLAN - where the nodes live
+auto vlan189
+iface vlan189
+    address {{ vlan_189_address }}
+    address-virtual 00:00:5E:00:01:01 10.89.0.1/24
+    vlan-id 189
+    vlan-raw-device bridge
+    vrf prod
+    mtu 9216
+
+#DEV VLAN in use to PEER with Main Network - VRF Public
+auto vlan288
+iface vlan288
+    address {{ vlan_288_address }}
+    vlan-id 288
+    vlan-raw-device bridge
+    vrf dev
+    mtu 9216
+
+#PROD VLAN in use to PEER with Main Network - VRF Public
+auto vlan289
+iface vlan289
+    address {{ vlan_289_address }}
+    vlan-id 289
+    vlan-raw-device bridge
+    vrf prod
+    mtu 9216
+
+#PROD Vlan in use for NETAPP (Storage)
+auto vlan1000
+iface vlan1000
+   address {{ vlan_1000_address }}
+   address-virtual 00:00:5E:00:01:04 10.10.50.1/24
+   vlan-id 1000
+   vlan-raw-device bridge
+   vrf prod
+   mtu 9216
+
+#DEV Vlan in use for NETAPP (Storage)
+auto vlan2000
+iface vlan2000
+   address {{ vlan_2000_address }}
+   address-virtual 00:00:5E:00:01:04 10.20.50.1/24
+   vlan-id 2000
+   vlan-raw-device bridge
+   vrf dev
+   mtu 9216


### PR DESCRIPTION
Add a new interfaces template and host specific variables
Add a handler to `sudo ifreload -a` on /etc/network/interfaces change

`DRY_RUN=true make cumulus ARGS="--tags=network"` gives the following differences (mostly fmt):
```
--- before: /etc/network/interfaces                                                                                                                                                                         
+++ after: /home/foivos/go/src/github.com/utilitywarehouse/sys-ansible-k8s-on-prem/"/tmp"/ansible-local-19296DuSkS/tmpeISxGB/network-interfaces.tmpl                                                        
@@ -1,6 +1,5 @@                                                                                                                                                                                             
 # This file describes the network interfaces available on your system                                                                                                                                      
 # and how to activate them. For more information, see interfaces(5).                                                                                                                                       
-                                                                                                                                                                                                           
 source /etc/network/interfaces.d/*.intf                                                                                                                                                                    
                                                                                                                                                                                                            
 # The loopback network interface                                                                                                                                                                           
@@ -73,22 +72,21 @@                                                                                                                                                                                         
     bridge-vids 2000                                                                                                                                                                                       
     mtu 9216                                                                                                                                                                                               
                                                                                                                                                                                                            
-#Link to Moonshoot 1  (New one-DEV)                                                                                                                                                                        
+#Link to Moonshoot 1 (New one - DEV)                                                                                                                                                                       
 auto swp30                                                                                                                                                                                                 
 iface swp30                                                                                                                                                                                                
     mtu 9216                                                                                                                                                                                               
                                                                                                                                                                                                            
-#Link to Moonshot 1  ( New one - PROD)                                                                                                                                                                     
+#Link to Moonshot 1 (New one - PROD)                                                                                                                                                                       
 auto swp27                                                                                                                                                                                                 
 iface swp27                                                                                                                                                                                                
     link-down yes                                                                                                                                                                                          
     mtu 9216                                                                                                                                                                                               
                                                                                                                                                                                                            
-#Link to Moonshoot 0(Old one - DEV)                                                                                                                                                                        
+#Link to Moonshoot 0 (Old one - DEV)                                                                                                                                                                       
 auto swp31                                                                                                                                                                                                 
 iface swp31                                                                                                                                                                                                
     mtu 9216                                                                                                                                                                                               
-                                                                                                                                                                                                           
                                                                                                                                                                                                            
 #PO to Merit-network-VPC                                                                                                                                                                                   
 auto bond-mer-mer                                                                                                                                                                                          
@@ -114,7 +112,6 @@                                                                                                                                                                                         
     clag-id 27                                                                                                                                                                                             
     mtu 9216                                                                                                                                                                                               
                                                                                                                                                                                                            
-                                                                                                                                                                                                           
 #PO to Moonshoot DEV (Old one) - One iface per SW in MLAG                                                                                                                                                  
 auto bond-hp-m0-dev                                                                                                                                                                                        
 iface bond-hp-m0-dev                                                                                                                                                                                       
@@ -122,7 +119,6 @@                                                                                                                                                                                         
     bridge-vids 188 189                                                                                                                                                                                    
     clag-id 31                                                                                                                                                                                             
     mtu 9216                                                                                                                                                                                               
-

 #Brigde interface (All L2 Interfaces)
 auto bridge
@@ -158,7 +154,7 @@
    vlan-raw-device bridge
    mtu 9216

-#DEV- VLAN in use to PEER with Main Network -VRF internal 
+#DEV- VLAN in use to PEER with Main Network - VRF internal
 auto vlan88
 iface vlan88
     address 172.30.88.253/24
@@ -167,7 +163,7 @@
     vrf dev
     mtu 9216

-#PROD- VLAN in use to PEER with Main Network -VRF internal 
+#PROD- VLAN in use to PEER with Main Network - VRF internal
 auto vlan89
 iface vlan89
     address 172.30.89.253/24
@@ -224,7 +220,7 @@
    vrf prod
    mtu 9216

-#DEV -Vlan in use for NETAPP (Storage)
+#DEV Vlan in use for NETAPP (Storage)
 auto vlan2000
 iface vlan2000
    address 10.20.50.253/24
@@ -233,4 +229,3 @@
    vlan-raw-device bridge
    vrf dev
    mtu 9216
-

changed: [10.91.5.104]
```

```
--- before: /etc/network/interfaces                                                                                                                                                                [87/2452]
+++ after: /home/foivos/go/src/github.com/utilitywarehouse/sys-ansible-k8s-on-prem/"/tmp"/ansible-local-19296DuSkS/tmpjmWHd0/network-interfaces.tmpl
@@ -1,6 +1,5 @@
 # This file describes the network interfaces available on your system
 # and how to activate them. For more information, see interfaces(5).
-
 source /etc/network/interfaces.d/*.intf

 # The loopback network interface
@@ -22,7 +21,7 @@
     address ::1/128
     vrf-table auto

-#PeerLink Bond Interface (MLAG setup)
+#PeerLink Bond interace
 auto swp1
 iface swp1
     mtu 9216
@@ -33,15 +32,15 @@
     mtu 9216
     link-speed 400000

-#Link to Merit-Network VPC
+#Link to Merit-Network-VPC
 auto swp3
 iface swp3
-    mtu 9216
-
-#Link to Merit-Network VPC
+     mtu 9216
+
+#Link to Merit-Network-VPC
 auto swp4
 iface swp4
-    mtu 9216
+     mtu 9216

 #PROD - Link to Netapp Controller "A" ( No Bond interface is supported by NetApp)
 auto swp5
@@ -72,25 +71,24 @@                                                                                                                                                                                [48/2452]
     alias swp29 dev-netapp-ctrl-b
     bridge-vids 2000
     mtu 9216
-    link-autoneg on
-
-#Link to Moonshoot 1  (New one-DEV)
+
+#Link to Moonshoot 1 (New one - DEV)
 auto swp30
 iface swp30
     mtu 9216

-#Link to Moonshot 1  ( New one - PROD)
+#Link to Moonshot 1 (New one - PROD)
 auto swp27
 iface swp27
-    link-down yes
-    mtu 9216
-
-#Link to Moonshoot 0(Old one - DEV)
+    link-down yes
+    mtu 9216
+
+#Link to Moonshoot 0 (Old one - DEV)
 auto swp31
 iface swp31
     mtu 9216

-#PO to Merit-Network -VPC
+#PO to Merit-network-VPC
 auto bond-mer-mer
 iface bond-mer-mer
     bond-slaves swp3 swp4
@@ -113,7 +111,6 @@
     bridge-vids 189
     clag-id 27
     mtu 9216
-

 #PO to Moonshoot DEV (Old one) - One iface per SW in MLAG
 auto bond-hp-m0-dev
@@ -132,7 +129,6 @@
     mstpctl-treeprio 8192
     mtu 9216

-
 #PeerLink bond for MLAG setup
 auto peerlink
 iface peerlink
@@ -150,7 +146,7 @@
 iface prod
     vrf-table auto

-#This is a standard vlan created for CLAG-Backup LINK (Default VRF)
+#This is an standard vlan created for CLAG-Backup LINK
 auto vlan2
 iface vlan2
    address 10.254.254.254/30
@@ -158,7 +154,7 @@
    vlan-raw-device bridge
    mtu 9216

-#DEV VLAN in use to PEER with Main Network -VRF internal
+#DEV- VLAN in use to PEER with Main Network - VRF internal
 auto vlan88
 iface vlan88
     address 172.30.88.254/24
@@ -167,7 +163,7 @@
     vrf dev
     mtu 9216

-#PROD VLAN in use to PEER with Main Network -VRF internal
+#PROD- VLAN in use to PEER with Main Network - VRF internal
 auto vlan89
 iface vlan89
     address 172.30.89.254/24
@@ -224,7 +220,7 @@
    vrf prod
    mtu 9216

-#DEV -Vlan in use for NETAPP (Storage)
+#DEV Vlan in use for NETAPP (Storage)
 auto vlan2000
 iface vlan2000
    address 10.20.50.254/24

changed: [10.91.5.105]
```

main thing to notice is the change on cumulus-2 dev-netapp-ctrl-b interface:
```
@@ -72,25 +71,24 @@                                                                                                                                                                                [48/2452]
     alias swp29 dev-netapp-ctrl-b
     bridge-vids 2000
     mtu 9216
-    link-autoneg on
-
```