### PR TITLE
cumulus: add natting rules and interafce for dev

### DIFF
--- a/inventories/hosts
+++ b/inventories/hosts
@@ -18,6 +18,7 @@ vlan_288_address=192.168.88.253/24
 vlan_289_address=192.168.89.253/24
 vlan_1000_address=10.10.50.253/24
 vlan_2000_address=10.20.50.253/24
+dev_nat_ip_address=85.91.50.253
 
 [cumulus-2]
 10.91.5.105
@@ -37,6 +38,7 @@ vlan_288_address=192.168.88.254/24
 vlan_289_address=192.168.89.254/24
 vlan_1000_address=10.10.50.254/24
 vlan_2000_address=10.20.50.254/24
+dev_nat_ip_address=85.91.50.254
 
 [dhcp-dev:children]
 cumulus

--- a/roles/cumulus/files/switchd.conf
+++ b/roles/cumulus/files/switchd.conf
@@ -1,0 +1,161 @@
+#
+# /etc/cumulus/switchd.conf - switchd configuration file
+#
+
+# Statistic poll interval (in msec)
+#stats.poll_interval = 2000
+
+# Buffer utilization poll interval (in msec), 0 means disable
+#buf_util.poll_interval = 0
+
+# Buffer utilization measurement interval (in mins)
+#buf_util.measure_interval = 0
+
+# Optimize ACL HW resources for better utilization
+#acl.optimize_hw = FALSE
+
+# Enable Flow based mirroring.
+#acl.flow_based_mirroring = TRUE
+
+# Enable non atomic acl update
+acl.non_atomic_update_mode = FALSE
+
+# Send ARPs for next hops
+#arp.next_hops = TRUE
+
+# Kernel routing table ID, range 1 - 2^31, default 254
+#route.table = 254
+
+# Maximum hardware neighbor table occupancy (percent of hardware table size)
+#route.host_max_percent = 100
+
+# Coalescing reduction factor for accumulating changes to reduce CPU load
+#coalescing.reducer = 1
+
+# Coalescing time limit, in seconds
+#coalescing.timeout = 10
+
+# Ignore routes that point to non-swp interfaces
+ignore_non_swps = TRUE
+
+# Disables restart after parity error
+#disable_internal_parity_restart = TRUE
+
+# Disables restart after an unrecoverable hardware error
+#disable_internal_hw_err_restart = FALSE
+
+# NAT configuration
+# Enables NAT
+#nat.static_enable = TRUE
+nat.dynamic_enable = TRUE
+
+# NAT age poll interval in minute(s) {minimum=1m, maximum=24h}
+# Note: Configuration is allowed only when nat.dynamic_enable is enabled
+#nat.age_poll_interval = 5
+
+# NAT table size limits in number of entries
+# Note: Configuration is allowed only when nat.dynamic_enable is enabled
+# table_size
+# config_table_size
+#nat.table_size = 1024
+#nat.config_table_size = 64
+
+# Log messages using the given BACKEND=LEVEL,
+# space separate multiple BACKEND=LEVEL pairs.
+# BACKEND := {stderr, file:filename, syslog, program:executable},
+# LEVEL := {CRIT, ERR, WARN, INFO, DEBUG}
+# Prior to Cumulus Linux 2.5.4, file:/var/log/switchd.log=INFO was the default
+logging = syslog=INFO
+
+# Storm Control setting on a port, in pps, 0 means disable
+#interface.swp1.storm_control.broadcast = 400
+#interface.swp1.storm_control.multicast = 3000
+
+# Maximum route limit
+#route.max_routes = 32768
+
+# Enable HW statistics
+# level specifies type of stats needed per-hw resource type.
+# LEVEL := {NONE, BRIEF, DETAIL}
+#stats.vlan.aggregate = BRIEF
+#stats.vxlan.aggregate = DETAIL
+#stats.vxlan.member = BRIEF
+
+#stats.vlan.show_internal_vlans = FALSE
+
+# Virtual devices hw-stat poll interval (in seconds)
+#stats.vdev_hw_poll_interval = 5
+
+# Internal VLAN range
+# minimum range size is 150
+#resv_vlan_range = 3600-3999
+
+# Netlink
+# netlink socket buf size (90 * 1024 * 1024 = 90MB)
+#netlink.buf_size=94371840
+
+# delete routes on interfaces when carrier is down
+#route.delete_dead_routes = TRUE
+
+# default TTL to use in vxlan header
+#vxlan.default_ttl = 64
+
+# bridge broadcast frame to cpu even if SVI is not enabled
+#bridge.broadcast_frame_to_cpu = FALSE
+
+#netlink libnl logger [0-5]
+#netlink.nl_logger = 0
+
+# router mac lookup per vlan
+#hal.bcm.per_vlan_router_mac_lookup = FALSE
+
+# vrrp vmac lookup per vlan
+#hal.bcm.l3.per_vlan_router_mac_lookup_for_vrrp = FALSE
+
+#IGMP snooping optimized multicast forwarding
+#bridge.optimized_mcast_flood = FALSE
+
+# default vxlan outer dscp action during encap
+# {copy | set | derive}
+# copy: only if inner packet is IP
+# set: to specific value
+# derive: from switch priority
+#vxlan.def_encap_dscp_action = derive
+
+# default vxlan encap dscp value, only applicable if action is 'set'
+#vxlan.def_encap_dscp_value =
+
+# default vxlan decap dscp/cos action
+# {copy | preserve | derive}
+# copy: only if inner packet is IP
+# preserve: inner dscp unchanged
+# derive: from switch priority
+#vxlan.def_decap_dscp_action = derive
+
+# Enable send unknown ipmc to CPU
+#ipmulticast.unknown_ipmc_to_cpu = FALSE
+
+#Disable L3MC on SVI
+#By default, L3MC is enabled on SVI.
+#ipmulticast.svi_l3mc_disable = FALSE
+
+# Bridge L2MC Link-Local multicast punt disable
+#hal.bcm.ll_mcast_punt_disable = TRUE
+
+#enable ptp time stamping
+#ptp.timestamping = FALSE
+
+#dynamic vrf route leak enable
+#vrf_route_leak_enable_dynamic = FALSE
+
+#event queue depth value
+#sync_queue_depth_val = 50000
+
+# configure a route instead of a neighbor with the same ip/mask
+#route.route_preferred_over_neigh = TRUE
+
+# configure IP based forwarding for L2 Multicast
+#bridge.dip_based_l2multicast = FALSE
+
+# vxlan policers; each pair separated by comma
+#hal.bcm.vxlan_policers = tunnel_arp=400,tunnel_dhcp_v4=100,tunnel_dhcp_v6=100,tunnel_ttl1=100,tunnel_rs=300,tunnel_ra=300,tunnel_ns=300,tunnel_na=300,local_arp=400,local_rs=300,local_ra=300,local_ns=300,local_na=300

--- a/roles/cumulus/handlers/main.yaml
+++ b/roles/cumulus/handlers/main.yaml
@@ -23,3 +23,9 @@
     name: node-exporter.service
     state: restarted
   become: yes
+
+- name: restart switchd
+  service:
+    name: switchd.service
+    state: restarted
+  become: yes

--- a/roles/cumulus/tasks/main.yaml
+++ b/roles/cumulus/tasks/main.yaml
@@ -9,8 +9,8 @@
     src: "files/10ssh.rules"
     dest: "/etc/cumulus/acl/policy.d/10ssh.rules"
   notify:
-    - "install ACL rules"
-  tags: ssh_rules
+    - install ACL rules
+  tags: ssh_rules, acl_rules
 
 - name: Copy frr configuration
   template:
@@ -70,3 +70,21 @@
   notify:
     - reload network interfaces
   tags: network
+
+# files/switchd.conf is grabbed directly from a cumulus host and has the desired
+# configuration (nat) uncommented
+- name: copy switchd.conf
+  copy:
+    src: "files/switchd.conf"
+    dest: "/etc/cumulus/switchd.conf"
+  notify:
+    - restart switchd
+  tags: switchd, nat
+
+- name: Copy nat rules
+  template:
+    src: 60_nat.rules.tmpl
+    dest: "/etc/cumulus/acl/policy.d/60_nat.rules"
+  notify:
+    - install ACL rules
+  tags: acl_rules, nat

--- a/roles/cumulus/templates/60_nat.rules.tmpl
+++ b/roles/cumulus/templates/60_nat.rules.tmpl
@@ -1,1 +1,5 @@
 -t nat -A POSTROUTING -s 10.88.0.0/24 ! -d 10.0.0.0/8 -j SNAT --to-source {{ dev_nat_ip_address }}
+
+# Block traffic going directly to nat ip
+-A INPUT -i vlan388 -m state --state ESTABLISHED,RELATED -j ACCEPT
+-A INPUT -d {{ dev_nat_ip_address }}/32 -j DROP

--- a/roles/cumulus/templates/60_nat.rules.tmpl
+++ b/roles/cumulus/templates/60_nat.rules.tmpl
@@ -1,0 +1,1 @@
+-t nat -A POSTROUTING -s 10.88.0.0/24 ! -d 10.0.0.0/8 -j SNAT --to-source {{ dev_nat_ip_address }}

--- a/roles/cumulus/templates/network-interfaces.tmpl
+++ b/roles/cumulus/templates/network-interfaces.tmpl
@@ -124,7 +124,7 @@ iface bond-hp-m0-dev
 auto bridge
 iface bridge
     bridge-ports peerlink bond-hp-m0-dev bond-hp-m1-dev bond-hp-m1-prod bond-mer-mer swp5 swp6 swp28 swp29
-    bridge-vids 2 88 89 188 189 288 289 1000 2000
+    bridge-vids 2 88 89 188 189 288 289 388 1000 2000
     bridge-vlan-aware yes
     mstpctl-treeprio 8192
     mtu 9216
@@ -229,3 +229,12 @@ iface vlan2000
    vlan-raw-device bridge
    vrf dev
    mtu 9216
+
+#DEV VLAN in use by the nat interface
+auto vlan388
+iface vlan388
+    address {{ dev_nat_ip_address }}/24
+    vlan-id 388
+    vlan-raw-device bridge
+    vrf dev
+    mtu 9216


### PR DESCRIPTION
`switchd.conf` file is copied from cumulus and the line to enable dynamic nat is uncommented.

Changes from `DRY_RUN=true make cumulus ARGS="--tags=network,nat"`
```
--- before: /etc/network/interfaces                                                                                                                                                                         
+++ after: /home/foivos/go/src/github.com/utilitywarehouse/sys-ansible-k8s-on-prem/"/tmp"/ansible-local-17530XADUfr/tmpVgzC3F/network-interfaces.tmpl                                                       
@@ -124,7 +124,7 @@                                                                                                                                                                                         
 auto bridge                                                                                                                                                                                                
 iface bridge                                                                                                                                                                                               
     bridge-ports peerlink bond-hp-m0-dev bond-hp-m1-dev bond-hp-m1-prod bond-mer-mer swp5 swp6 swp28 swp29                                                                                                 
-    bridge-vids 2 88 89 188 189 288 289 1000 2000                                                                                                                                                          
+    bridge-vids 2 88 89 188 189 288 289 388 1000 2000                                                                                                                                                      
     bridge-vlan-aware yes                                                                                                                                                                                  
     mstpctl-treeprio 8192                                                                                                                                                                                  
     mtu 9216                                                                                                                                                                                               
@@ -229,3 +229,12 @@                                                                                                                                                                                        
    vlan-raw-device bridge                                                                                                                                                                                  
    vrf dev                                                                                                                                                                                                 
    mtu 9216                                                                                                                                                                                                
+                                                                                                                                                                                                           
+#DEV VLAN in use by the nat interface                                                                                                                                                                      
+auto vlan388                                                                                                                                                                                               
+iface vlan388                                                                                                                                                                                              
+    address 85.91.50.254/24                                                                                                                                                                                
+    vlan-id 388                                                                                                                                                                                            
+    vlan-raw-device bridge                                                                                                                                                                                 
+    vrf dev                                                                                                                                                                                                
+    mtu 9216                                                                                                                                                                                               
                                                                                                                                                                                                            
changed: [10.91.5.105]                                                                                                                                                                                      
--- before: /etc/network/interfaces                                                                                                                                                                         
+++ after: /home/foivos/go/src/github.com/utilitywarehouse/sys-ansible-k8s-on-prem/"/tmp"/ansible-local-17530XADUfr/tmpPDJTCI/network-interfaces.tmpl                                                       
@@ -124,7 +124,7 @@                                                                                                                                                                                         
 auto bridge                                                                                                                                                                                                
 iface bridge                                                                                                                                                                                               
     bridge-ports peerlink bond-hp-m0-dev bond-hp-m1-dev bond-hp-m1-prod bond-mer-mer swp5 swp6 swp28 swp29                                                                                                 
-    bridge-vids 2 88 89 188 189 288 289 1000 2000                                                                                                                                                          
+    bridge-vids 2 88 89 188 189 288 289 388 1000 2000                                                                                                                                                      
     bridge-vlan-aware yes                                                                                                                                                                                  
     mstpctl-treeprio 8192                                                                                                                                                                                  
     mtu 9216                                                                                                                                                                                               
@@ -229,3 +229,12 @@                                                                                                                                                                                        
    vlan-raw-device bridge                                                                                                                                                                                  
    vrf dev                                                                                                                                                                                                 
    mtu 9216                                                                                                                                                                                                
+                                                                                                                                                                                                           
+#DEV VLAN in use by the nat interface                                                                                                                                                                      
+auto vlan388                                                                                                                                                                                               
+iface vlan388                                                                                                                                                                                              
+    address 85.91.50.253/24                                                                                                                                                                                
+    vlan-id 388                                                                                                                                                                                            
+    vlan-raw-device bridge                                                                                                                                                                                 
+    vrf dev                                                                                                                                                                                                
+    mtu 9216                                                                                                                                                                                               
                                                                                                                                                                                                            
changed: [10.91.5.104]                          
```

```
--- before: /etc/cumulus/switchd.conf                                                                                                                                                                       
+++ after: /home/foivos/go/src/github.com/utilitywarehouse/sys-ansible-k8s-on-prem/roles/cumulus/files/switchd.conf                                                                                         
@@ -47,7 +47,7 @@                                                                                                                                                                                           
 # NAT configuration                                                                                                                                                                                        
 # Enables NAT                                                                                                                                                                                              
 #nat.static_enable = TRUE                                                                                                                                                                                  
-#nat.dynamic_enable = TRUE                                                                                                                                                                                 
+nat.dynamic_enable = TRUE                                                                                                                                                                                  
                                                                                                                                                                                                            
 # NAT age poll interval in minute(s) {minimum=1m, maximum=24h}
 # Note: Configuration is allowed only when nat.dynamic_enable is enabled

changed: [10.91.5.104]
--- before: /etc/cumulus/switchd.conf
+++ after: /home/foivos/go/src/github.com/utilitywarehouse/sys-ansible-k8s-on-prem/roles/cumulus/files/switchd.conf
@@ -47,7 +47,7 @@
 # NAT configuration
 # Enables NAT
 #nat.static_enable = TRUE
-#nat.dynamic_enable = TRUE
+nat.dynamic_enable = TRUE

 # NAT age poll interval in minute(s) {minimum=1m, maximum=24h}
 # Note: Configuration is allowed only when nat.dynamic_enable is enabled

changed: [10.91.5.105]
```

```
--- before
+++ after: /home/foivos/go/src/github.com/utilitywarehouse/sys-ansible-k8s-on-prem/"/tmp"/ansible-local-17530XADUfr/tmpcTQgFB/60_nat.rules.tmpl
@@ -0,0 +1 @@
+-t nat -A POSTROUTING -s 10.88.0.0/24 ! -d 10.0.0.0/8 -j SNAT --to-source 85.91.50.254

changed: [10.91.5.105]
--- before
+++ after: /home/foivos/go/src/github.com/utilitywarehouse/sys-ansible-k8s-on-prem/"/tmp"/ansible-local-17530XADUfr/tmpzMtFWq/60_nat.rules.tmpl
@@ -0,0 +1 @@
+-t nat -A POSTROUTING -s 10.88.0.0/24 ! -d 10.0.0.0/8 -j SNAT --to-source 85.91.50.253

changed: [10.91.5.104]

```