### PR TITLE
matchbox prod deployment

### DIFF
--- a/inventories/group_vars/dhcp-dev
+++ b/inventories/group_vars/dhcp-dev
@@ -10,3 +10,6 @@ dns: 1.1.1.1,1.0.0.1
 
 # matchbox address
 dhcp_matchbox: 'http://matchbox.dev.merit.uw.systems:80/boot.ipxe'
+# actual matchbox local hosts cannot be relying on themselves to boot so we need
+# an external matchbox server that will be able to boot those.
+dhcp_matchbox_external: 'http://matchbox.dev.gcp.uw.systems:80/boot.ipxe'

--- a/inventories/group_vars/dhcp-prod
+++ b/inventories/group_vars/dhcp-prod
@@ -10,3 +10,6 @@ dns: 1.1.1.1,1.0.0.1
 
 # matchbox address
 dhcp_matchbox: 'http://matchbox.prod.gcp.uw.systems:80/boot.ipxe'
+# actual matchbox local hosts cannot be relying on themselves to boot so we need
+# an external matchbox server that will be able to boot those.
+dhcp_matchbox_external: 'http://matchbox.prod.gcp.uw.systems:80/boot.ipxe'

--- a/inventories/group_vars/hosts-prod
+++ b/inventories/group_vars/hosts-prod
@@ -164,8 +164,15 @@ workers_prod:
       - ec:eb:b8:a5:a2:52
       - ec:eb:b8:a5:a2:53
 
-# empty matchbox to comply with the config template
-matchbox_prod: []
+matchbox_prod:
+  - ip_address: 10.89.0.248
+    mac_addresses:
+      - fc:15:b4:24:3f:22
+      - fc:15:b4:24:3f:23
+  - ip_address: 10.89.0.249
+    mac_addresses:
+      - fc:15:b4:24:7f:a2
+      - fc:15:b4:24:7f:a3
 
 # empty wiresteward to comply with the config template
 wiresteward_prod: []

--- a/inventories/group_vars/netapp-prod
+++ b/inventories/group_vars/netapp-prod
@@ -19,7 +19,6 @@ cfssl_network_gateway: 10.10.50.1
 cfssl_lif_netmask: 255.255.255.0
 cfssl_data_lif_1_address: 10.10.50.14
 cfssl_data_lif_2_address: 10.10.50.15
-cfssl_mgmt_lif_address: 10.10.50.16
 cfssl_chap_password: "{{vault_cfssl_chap_password_prod}}"
 cfssl_igroup_initiator: "iqn.2005-03.org.open-iscsi:cfssl"
 cfssl_initiator_ip: 10.89.0.8
@@ -36,3 +35,15 @@ kube_mgmt_lif_address: 10.10.50.6
 
 kube_trident_user: trident
 kube_trident_password: "{{vault_kube_trident_password_prod}}"
+
+# nfs
+nfs_aggregate_list:
+  - system_01_SSD_1
+  - system_02_SSD_1
+nfs_network_gateway: 10.10.50.1
+nfs_lif_netmask: 255.255.255.0
+nfs_data_lif_1_address: 10.10.50.24
+
+# matchbox
+matchbox_volume_aggregate: system_02_SSD_1
+matchbox_ips: 10.89.0.248,10.89.0.249

--- a/roles/cumulus/templates/frr.conf.tmpl
+++ b/roles/cumulus/templates/frr.conf.tmpl
@@ -68,6 +68,9 @@ router bgp 64512 vrf prod
 {% for w in workers_prod %}
  neighbor {{ w.ip_address }} remote-as 64512
 {% endfor %}
+{% for m in matchbox_prod %}
+ neighbor {{ m.ip_address }} remote-as 64512
+{% endfor %}
  neighbor 172.30.89.1 remote-as 51553
  neighbor 172.30.89.1 password {{ core_network_bgp_password }}
  neighbor 172.30.89.2 remote-as 51553

--- a/roles/dhcp/templates/dhcp.conf.tmpl
+++ b/roles/dhcp/templates/dhcp.conf.tmpl
@@ -96,7 +96,7 @@ host matchbox-{{ matchbox_count }}-{{ loop.index }} {
   hardware ethernet {{ mac_address }};
   fixed-address {{ m.ip_address }};
   if exists user-class and option user-class = "iPXE" {
-    filename "{{ dhcp_matchbox }}";
+    filename "{{ dhcp_matchbox_external }}";
   } else {
     filename "ipxe.pxe";
   }


### PR DESCRIPTION
- add dhcp configuration
- add bgp peers on the new matchbox hosts addresses
- create netapp svm, export policy and volume