### PR TITLE
Allow forwarding traffic from public subnets

### DIFF
--- a/roles/cumulus/files/10ssh.rules
+++ b/roles/cumulus/files/10ssh.rules
@@ -5,6 +5,10 @@
 -A FORWARD -p tcp -s 10.91.0.0/16 -d 10.89.0.0/24 --dport 22 -j ACCEPT
 -A FORWARD -s 10.88.0.0/24 -j ACCEPT
 -A FORWARD -s 10.89.0.0/24 -j ACCEPT
+# Since we are natting all traffic on moonshot nodes (so before hitting cumulus
+# for the last time before packets are routed out) we need to allow forwarding
+# packets from our public subnets as well. Otherwise all traffic from one of our
+# public addresses to dport 22 will be dropped.
 -A FORWARD -s 85.91.50.0/24 -j ACCEPT
 -A FORWARD -s 85.91.53.0/24 -j ACCEPT
 -A FORWARD -p tcp --dport 22 -j DROP

--- a/roles/cumulus/files/10ssh.rules
+++ b/roles/cumulus/files/10ssh.rules
@@ -5,4 +5,6 @@
 -A FORWARD -p tcp -s 10.91.0.0/16 -d 10.89.0.0/24 --dport 22 -j ACCEPT
 -A FORWARD -s 10.88.0.0/24 -j ACCEPT
 -A FORWARD -s 10.89.0.0/24 -j ACCEPT
+-A FORWARD -s 85.91.50.0/24 -j ACCEPT
+-A FORWARD -s 85.91.53.0/24 -j ACCEPT
 -A FORWARD -p tcp --dport 22 -j DROP


### PR DESCRIPTION
Needed since all traffic is natted out before reaching cumulus for the last
time. Specifically it prevented dev-merit from accessing github.com:22