### PR TITLE
Remove ansible version check from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,22 +9,19 @@ check-test:
 	echo $(check_flag)
 	echo $(DRY_RUN)
 
-version-check:
-	ansible --version | head -n 1 | awk '$$2<2.7 {print "ansible version < 2.7"; exit 1}'
-
-dhcp-dev: version-check
+dhcp-dev:
 	ansible-playbook -i inventories/hosts dhcp_dev.yaml --diff $(check_flag) $(ARGS)
 
-dhcp-prod: version-check
+dhcp-prod:
 	ansible-playbook -i inventories/hosts dhcp_prod.yaml --diff $(check_flag) $(ARGS)
 
-netapp-dev: version-check
+netapp-dev:
 	ansible-playbook -i inventories/hosts netapp_dev.yaml --diff $(check_flag) $(ARGS)
 
-netapp-prod: version-check
+netapp-prod:
 	ansible-playbook -i inventories/hosts netapp_prod.yaml --diff $(check_flag) $(ARGS)
 
-cumulus: version-check
+cumulus:
 	ansible-playbook -i inventories/hosts cumulus.yaml --diff $(check_flag) $(ARGS)
 
 netapp-collections-install:


### PR DESCRIPTION
The awk check is comparing chars, so it started failing when upgrading to
versions >= 2.10