### PR TITLE
Refactor dhcp config template and add exp dhcp service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ check-test:
 dhcp-dev:
 	ansible-playbook -i inventories/hosts dhcp_dev.yaml --diff $(check_flag) $(ARGS)
 
+dhcp-exp:
+	ansible-playbook -i inventories/hosts dhcp_exp.yaml --diff $(check_flag) $(ARGS)
+
 dhcp-prod:
 	ansible-playbook -i inventories/hosts dhcp_prod.yaml --diff $(check_flag) $(ARGS)
 

--- a/cumulus.yaml
+++ b/cumulus.yaml
@@ -7,5 +7,6 @@
     - inventories/group_vars/cumulus
     - inventories/group_vars/vault
     - inventories/group_vars/hosts-dev
+    - inventories/group_vars/hosts-exp
     - inventories/group_vars/hosts-prod
   become: yes

--- a/dhcp_exp.yaml
+++ b/dhcp_exp.yaml
@@ -1,0 +1,9 @@
+- hosts: dhcp-dev
+  user: cumulus
+  connection: ssh
+  roles:
+    - dhcp
+  vars_files:
+    - inventories/group_vars/dhcp-exp
+    - inventories/group_vars/hosts-exp
+  become: yes

--- a/inventories/group_vars/dhcp-dev
+++ b/inventories/group_vars/dhcp-dev
@@ -1,19 +1,16 @@
 # interfaces
 dhcp_listen_interface: vlan188
 dhcp_vrf_name: dev
+dhcp_role_name: dev
 
 subnet: 10.88.0.0
 netmask: 255.255.255.0
 router: 10.88.0.1
 domain_name: dev.merit.uw.systems
 dns: 1.1.1.1,1.0.0.1
-exp_domain_name: exp-1.merit.uw.systems
 
 # matchbox address
 dhcp_matchbox: 'http://matchbox.dev.merit.uw.systems:80/boot.ipxe'
 # actual matchbox local hosts cannot be relying on themselves to boot so we need
 # an external matchbox server that will be able to boot those.
 dhcp_matchbox_external: 'http://matchbox.dev.gcp.uw.systems:80/boot.ipxe'
-# For the exp cluster let's just use an external matchbox deployment under
-# the respective exp gcp cluster.
-exp_dhcp_matchbox_external: 'http://matchbox.exp-1.gcp.uw.systems:80/boot.ipxe'

--- a/inventories/group_vars/dhcp-exp
+++ b/inventories/group_vars/dhcp-exp
@@ -1,0 +1,16 @@
+# interfaces
+dhcp_listen_interface: vlan1188
+dhcp_vrf_name: dev
+dhcp_role_name: exp
+
+subnet: 10.88.10.0
+netmask: 255.255.255.0
+router: 10.88.10.1
+domain_name: exp-1.merit.uw.systems
+dns: 1.1.1.1,1.0.0.1
+
+# matchbox address
+dhcp_matchbox: 'http://matchbox.exp-1.gcp.uw.systems:80/boot.ipxe'
+# actual matchbox local hosts cannot be relying on themselves to boot so we need
+# an external matchbox server that will be able to boot those.
+dhcp_matchbox_external: 'http://matchbox.exp-1.gcp.uw.systems:80/boot.ipxe'

--- a/inventories/group_vars/dhcp-prod
+++ b/inventories/group_vars/dhcp-prod
@@ -1,6 +1,7 @@
 # interfaces
 dhcp_listen_interface: vlan189
 dhcp_vrf_name: prod
+dhcp_role_name: prod
 
 subnet: 10.89.0.0
 netmask: 255.255.255.0
@@ -13,6 +14,3 @@ dhcp_matchbox: 'http://matchbox.prod.merit.uw.systems:80/boot.ipxe'
 # actual matchbox local hosts cannot be relying on themselves to boot so we need
 # an external matchbox server that will be able to boot those.
 dhcp_matchbox_external: 'http://matchbox.prod.gcp.uw.systems:80/boot.ipxe'
-# Empty exp variables, so that the dhcp template doesn't complain
-exp_domain_name: ''
-exp_dhcp_matchbox_external: ''

--- a/inventories/group_vars/hosts-dev
+++ b/inventories/group_vars/hosts-dev
@@ -4,16 +4,6 @@ cfssl:
       - fc:15:b4:22:d6:42
       - fc:15:b4:22:d6:43
 
-exp_cfssl:
-  - ip_address: 10.88.10.8
-    mac_addresses:
-      - fc:15:b4:22:d6:44
-      - fc:15:b4:22:d6:45
-
-# Empty until we decommission prod gobgps as well, and remove from the dhcp
-# configuration template.
-gobgp: []
-
 etcd:
   - ip_address: 10.88.0.32
     mac_addresses:
@@ -27,20 +17,6 @@ etcd:
     mac_addresses:
       - a0:1d:48:b5:4b:58
       - a0:1d:48:b5:4b:59
-
-exp_etcd:
-  - ip_address: 10.88.10.32
-    mac_addresses:
-      - fc:15:b4:22:07:a2
-      - fc:15:b4:22:07:a3
-  - ip_address: 10.88.10.33
-    mac_addresses:
-      - fc:15:b4:22:07:a4
-      - fc:15:b4:22:07:a5
-  - ip_address: 10.88.10.34
-    mac_addresses:
-      - fc:15:b4:22:07:a6
-      - fc:15:b4:22:07:a7
 
 # Suffix masters and workers with environment so that we can use them via:
 # `vars["workers_" + env]` on roles where we do separate runs for dev and prod,
@@ -261,19 +237,3 @@ exp_wiresteward_dev:
     mac_addresses:
       - fc:15:b4:22:e6:9a
       - fc:15:b4:22:e6:9b
-
-exp_masters_dev:
-  - ip_address: 10.88.10.64
-    mac_addresses:
-      - a0:1d:48:b5:47:4c
-      - a0:1d:48:b5:47:4d
-
-exp_workers_dev:
-  - ip_address: 10.88.10.128
-    mac_addresses:
-      - a0:1d:48:b5:1d:74
-      - a0:1d:48:b5:1d:75
-  - ip_address: 10.88.10.129
-    mac_addresses:
-      - a0:1d:48:b5:1e:02
-      - a0:1d:48:b5:1e:03

--- a/inventories/group_vars/hosts-exp
+++ b/inventories/group_vars/hosts-exp
@@ -1,0 +1,37 @@
+cfssl:
+  - ip_address: 10.88.10.8
+    mac_addresses:
+      - fc:15:b4:22:d6:44
+      - fc:15:b4:22:d6:45
+
+etcd:
+  - ip_address: 10.88.10.32
+    mac_addresses:
+      - fc:15:b4:22:07:a2
+      - fc:15:b4:22:07:a3
+  - ip_address: 10.88.10.33
+    mac_addresses:
+      - fc:15:b4:22:07:a4
+      - fc:15:b4:22:07:a5
+  - ip_address: 10.88.10.34
+    mac_addresses:
+      - fc:15:b4:22:07:a6
+      - fc:15:b4:22:07:a7
+
+env: exp
+
+masters_exp:
+  - ip_address: 10.88.10.64
+    mac_addresses:
+      - a0:1d:48:b5:47:4c
+      - a0:1d:48:b5:47:4d
+
+workers_exp:
+  - ip_address: 10.88.10.128
+    mac_addresses:
+      - a0:1d:48:b5:1d:74
+      - a0:1d:48:b5:1d:75
+  - ip_address: 10.88.10.129
+    mac_addresses:
+      - a0:1d:48:b5:1e:02
+      - a0:1d:48:b5:1e:03

--- a/inventories/group_vars/hosts-prod
+++ b/inventories/group_vars/hosts-prod
@@ -121,10 +121,3 @@ nat_prod:
     mac_addresses:
       - fc:15:b4:24:3f:32
       - fc:15:b4:24:3f:33
-
-# Null all exps so that we can work with the same templates for dev and prod
-exp_wiresteward_prod: []
-exp_masters_prod: []
-exp_workers_prod: []
-exp_cfssl: []
-exp_etcd: []

--- a/roles/cumulus/templates/frr.conf.tmpl
+++ b/roles/cumulus/templates/frr.conf.tmpl
@@ -47,10 +47,10 @@ router bgp 64512 vrf dev
 {% for n in nat_dev %}
  neighbor {{ n.ip_address }} remote-as 64512
 {% endfor %}
-{% for me in exp_masters_dev %}
+{% for me in masters_exp %}
  neighbor {{ me.ip_address }} remote-as 64513
 {% endfor %}
-{% for we in exp_workers_dev %}
+{% for we in workers_exp %}
  neighbor {{ we.ip_address }} remote-as 64513
 {% endfor %}
  neighbor 172.30.88.1 remote-as 51553

--- a/roles/dhcp/tasks/main.yaml
+++ b/roles/dhcp/tasks/main.yaml
@@ -5,16 +5,16 @@
     update_cache: yes
   tags: dhcp
 
-- name: Create /etc/dhcp-{{ dhcp_vrf_name }}
+- name: Create /etc/dhcp-{{ dhcp_role_name }}
   file:
-    path: "/etc/dhcp-{{ dhcp_vrf_name }}"
+    path: "/etc/dhcp-{{ dhcp_role_name }}"
     state: directory
   tags: dhcp
 
 - name: Copy dhcp configuration
   template:
     src:  dhcp.conf.tmpl
-    dest: "/etc/dhcp-{{ dhcp_vrf_name }}/dhcp.conf"
+    dest: "/etc/dhcp-{{ dhcp_role_name }}/dhcp.conf"
   notify:
     - restart dhcp
   tags: dhcp
@@ -22,7 +22,7 @@
 - name: Copy dhcp system unit file
   template:
     src:  dhcp.service.tmpl
-    dest: "/etc/systemd/system/dhcp-{{ dhcp_vrf_name }}.service"
+    dest: "/etc/systemd/system/dhcp-{{ dhcp_role_name }}.service"
   notify:
     - daemon-reload
     - restart dhcp
@@ -30,7 +30,7 @@
 
 - name: Make sure dhcp is running and enabled
   service:
-    name: "dhcp-{{ dhcp_vrf_name }}"
+    name: "dhcp-{{ dhcp_role_name }}"
     state: started
     enabled: yes
   tags: dhcp
@@ -42,9 +42,9 @@
     update_cache: yes
   tags: dhcp
 
-- name: Create /etc/tftpboot-{{ dhcp_vrf_name }}
+- name: Create /etc/tftpboot-{{ dhcp_role_name }}
   file:
-    path: /etc/tftpboot-{{ dhcp_vrf_name }}
+    path: /etc/tftpboot-{{ dhcp_role_name }}
     state: directory
   tags: dhcp
 
@@ -56,7 +56,7 @@
 - name: Copy ipxe file into cumulus
   copy:
     src: roles/dhcp/files/ipxe.pxe
-    dest: "/etc/tftpboot-{{ dhcp_vrf_name }}/ipxe.pxe"
+    dest: "/etc/tftpboot-{{ dhcp_role_name }}/ipxe.pxe"
     mode: 0644
   tags: dhcp
 
@@ -64,14 +64,14 @@
 - name: Copy ipxe file into cumulus
   copy:
     src: roles/dhcp/files/ipxe.efi
-    dest: "/etc/tftpboot-{{ dhcp_vrf_name }}/ipxe.efi"
+    dest: "/etc/tftpboot-{{ dhcp_role_name }}/ipxe.efi"
     mode: 0644
   tags: dhcp
 
 - name: Copy atftp system unit file
   template:
     src:  atftp.service.tmpl
-    dest: "/etc/systemd/system/atftp-{{ dhcp_vrf_name }}.service"
+    dest: "/etc/systemd/system/atftp-{{ dhcp_role_name }}.service"
   notify:
     - daemon-reload
     - restart atftp
@@ -79,7 +79,7 @@
 
 - name: Make sure atftp is running and enabled
   service:
-    name: "atftp-{{ dhcp_vrf_name }}"
+    name: "atftp-{{ dhcp_role_name }}"
     state: started
     enabled: yes
   tags: dhcp

--- a/roles/dhcp/templates/dhcp.conf.tmpl
+++ b/roles/dhcp/templates/dhcp.conf.tmpl
@@ -27,6 +27,7 @@ host cfssl-{{ loop.index }} {
 {% endfor %}
 {% endfor %}
 
+{% if gobgp is defined %}
 ## GoBgp
 {% for g in gobgp %}
 {% set gobgp_count = loop.index-1 %}
@@ -43,6 +44,7 @@ host gobgp-{{ gobgp_count }}-{{ loop.index }} {
 }
 {% endfor %}
 {% endfor %}
+{% endif %}
 
 ## Etcd
 {% for e in etcd %}
@@ -87,6 +89,7 @@ host worker-{{ worker_count }}-{{ loop.index }} {
 {% endfor %}
 {% endfor %}
 
+{% if ("matchbox_" + env) in vars %}
 ## Matchbox
 {% for m in vars["matchbox_" + env] %}
 {% set matchbox_count = loop.index-1 %}
@@ -103,7 +106,9 @@ host matchbox-{{ matchbox_count }}-{{ loop.index }} {
 }
 {% endfor %}
 {% endfor %}
+{% endif %}
 
+{% if ("wiresteward_" + env) in vars %}
 ## Wiresteward
 {% for w in vars["wiresteward_" + env] %}
 {% set wiresteward_count = loop.index-1 %}
@@ -120,7 +125,9 @@ host wiresteward-{{ wiresteward_count }}-{{ loop.index }} {
 }
 {% endfor %}
 {% endfor %}
+{% endif %}
 
+{% if ("nat_" + env) in vars %}
 ## NAT boxes
 {% for n in vars["nat_" + env] %}
 {% set nat_count = loop.index-1 %}
@@ -137,8 +144,10 @@ host nat-{{ nat_count }}-{{ loop.index }} {
 }
 {% endfor %}
 {% endfor %}
+{% endif %}
 
-## Exp Nodes
+{% if ("exp_wiresteward_" + env) in vars %}
+## Exp Wiresteward
 {% for w in vars["exp_wiresteward_" + env] %}
 {% set wiresteward_count = loop.index-1 %}
 {% for mac_address in w.mac_addresses %}
@@ -154,54 +163,4 @@ host exp-wiresteward-{{ wiresteward_count }}-{{ loop.index }} {
 }
 {% endfor %}
 {% endfor %}
-{% for c in exp_cfssl %}
-{% for mac_address in c.mac_addresses %}
-host exp-cfssl-{{ loop.index }} {
-  option host-name "cfssl.{{ exp_domain_name }}";
-  hardware ethernet {{ mac_address }};
-  fixed-address {{ c.ip_address }};
-  if exists user-class and option user-class = "iPXE" {
-    filename "{{ exp_dhcp_matchbox_external }}";
-  } else {
-    filename "ipxe.pxe";
-  }
-}
-{% endfor %}
-{% endfor %}
-{% for e in exp_etcd %}
-{% set etcd_count = loop.index-1 %}
-{% for mac_address in e.mac_addresses %}
-host exp-etcd-{{ etcd_count }}-{{ loop.index }} {
-  option host-name "etcd-{{ etcd_count }}.{{ exp_domain_name }}";
-  hardware ethernet {{ mac_address }};
-  fixed-address {{ e.ip_address }};
-  filename "{{ exp_dhcp_matchbox_external }}";
-}
-{% endfor %}
-{% endfor %}
-{% for m in vars["exp_masters_" + env] %}
-{% set master_count = loop.index-1 %}
-{% for mac_address in m.mac_addresses %}
-host exp-master-{{ master_count }}-{{ loop.index }} {
-  option host-name "master-{{ master_count }}.{{ exp_domain_name }}";
-  hardware ethernet {{ mac_address }};
-  fixed-address {{ m.ip_address }};
-  filename "{{ exp_dhcp_matchbox_external }}";
-}
-{% endfor %}
-{% endfor %}
-{% for w in vars["exp_workers_" + env] %}
-{% set worker_count = loop.index-1 %}
-{% for mac_address in w.mac_addresses %}
-host exp-worker-{{ worker_count }}-{{ loop.index }} {
-  option host-name "worker-{{ worker_count }}.{{ exp_domain_name }}";
-  hardware ethernet {{ mac_address }};
-  fixed-address {{ w.ip_address }};
-  if exists user-class and option user-class = "iPXE" {
-    filename "{{ exp_dhcp_matchbox_external }}";
-  } else {
-    filename "ipxe.efi";
-  }
-}
-{% endfor %}
-{% endfor %}
+{% endif %}

--- a/roles/dhcp/templates/dhcp.service.tmpl
+++ b/roles/dhcp/templates/dhcp.service.tmpl
@@ -4,10 +4,10 @@ Documentation=man:dhcpd(8) man:dhcpd.conf(5)
 After=network-online.target networking.service syslog.service
 
 [Service]
-ExecStartPre=mkdir -p /etc/dhcp-{{ dhcp_vrf_name }}
-ExecStartPre=mkdir -p /var/lib/dhcp-{{ dhcp_vrf_name }}
-ExecStartPre=touch /var/lib/dhcp-{{ dhcp_vrf_name }}/dhcpd.leases
-ExecStart=/usr/sbin/ip vrf exec {{ dhcp_vrf_name }} /usr/sbin/dhcpd -p 67 -cf /etc/dhcp-{{ dhcp_vrf_name }}/dhcp.conf -lf /var/lib/dhcp-{{ dhcp_vrf_name }}/dhcpd.leases -pf /var/run/dhcp-{{ dhcp_vrf_name }}.pid  -d {{ dhcp_listen_interface }}
+ExecStartPre=mkdir -p /etc/dhcp-{{ dhcp_role_name }}
+ExecStartPre=mkdir -p /var/lib/dhcp-{{ dhcp_role_name }}
+ExecStartPre=touch /var/lib/dhcp-{{ dhcp_role_name }}/dhcpd.leases
+ExecStart=/usr/sbin/ip vrf exec {{ dhcp_vrf_name }} /usr/sbin/dhcpd -p 67 -cf /etc/dhcp-{{ dhcp_role_name }}/dhcp.conf -lf /var/lib/dhcp-{{ dhcp_role_name }}/dhcpd.leases -pf /var/run/dhcp-{{ dhcp_role_name }}.pid -d {{ dhcp_listen_interface }}
 Restart=on-failure
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Change jinja2 template to support optional blocks, instead of defining empty
  vars
- Add separate dhcp service for exp cluster on vlan 1188