### PR TITLE
Make ipxe binary in dhcp config configurable

### DIFF
--- a/inventories/group_vars/hosts-dev
+++ b/inventories/group_vars/hosts-dev
@@ -3,6 +3,7 @@ cfssl:
     mac_addresses:
       - fc:15:b4:22:d6:42
       - fc:15:b4:22:d6:43
+    ipxe_binary: ipxe.pxe
 
 etcd:
   - ip_address: 10.88.0.32
@@ -57,146 +58,182 @@ workers_dev:
     mac_addresses:
       - ec:eb:b8:a5:75:c2
       - ec:eb:b8:a5:75:c3
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.129
     mac_addresses:
       - ec:eb:b8:a5:c3:22
       - ec:eb:b8:a5:c3:23
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.130
     mac_addresses:
       - ec:eb:b8:a5:65:82
       - ec:eb:b8:a5:65:83
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.131
     mac_addresses:
       - ec:eb:b8:a5:60:82
       - ec:eb:b8:a5:60:83
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.132
     mac_addresses:
       - ec:eb:b8:a5:c3:72
       - ec:eb:b8:a5:c3:73
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.133
     mac_addresses:
       - ec:eb:b8:a5:e4:32
       - ec:eb:b8:a5:e4:33
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.134
     mac_addresses:
       - ec:eb:b8:a4:ef:62
       - ec:eb:b8:a4:ef:63
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.135
     mac_addresses:
       - ec:eb:b8:a5:c3:32
       - ec:eb:b8:a5:c3:33
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.136
     mac_addresses:
       - ec:eb:b8:a5:84:22
       - ec:eb:b8:a5:84:23
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.137
     mac_addresses:
       - ec:eb:b8:a5:45:92
       - ec:eb:b8:a5:45:93
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.138
     mac_addresses:
       - ec:eb:b8:a5:e4:72
       - ec:eb:b8:a5:e4:73
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.139
     mac_addresses:
       - ec:eb:b8:a5:42:f2
       - ec:eb:b8:a5:42:f3
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.140
     mac_addresses:
       - ec:eb:b8:a5:f4:82
       - ec:eb:b8:a5:f4:83
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.141
     mac_addresses:
       - ec:eb:b8:a5:13:d2
       - ec:eb:b8:a5:13:d3
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.142
     mac_addresses:
       - ec:eb:b8:a5:e3:f2
       - ec:eb:b8:a5:e3:f3
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.143
     mac_addresses:
       - ec:eb:b8:a4:cf:62
       - ec:eb:b8:a4:cf:63
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.144
     mac_addresses:
       - ec:eb:b8:a5:b2:52
       - ec:eb:b8:a5:b2:53
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.145
     mac_addresses:
       - ec:eb:b8:a5:03:f2
       - ec:eb:b8:a5:03:f3
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.146
     mac_addresses:
       - ec:eb:b8:a5:e3:c2
       - ec:eb:b8:a5:e3:c3
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.147
     mac_addresses:
       - ec:eb:b8:a4:bf:e2
       - ec:eb:b8:a4:bf:e3
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.148
     mac_addresses:
       - ec:eb:b8:a5:43:b2
       - ec:eb:b8:a5:43:b3
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.149
     mac_addresses:
       - ec:eb:b8:a5:94:a2
       - ec:eb:b8:a5:94:a3
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.150
     mac_addresses:
       - ec:eb:b8:a5:82:42
       - ec:eb:b8:a5:82:43
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.151
     mac_addresses:
       - ec:eb:b8:a5:83:a2
       - ec:eb:b8:a5:83:a3
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.152
     mac_addresses:
       - ec:eb:b8:a5:d2:22
       - ec:eb:b8:a5:d2:23
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.153
     mac_addresses:
       - ec:eb:b8:a5:83:72
       - ec:eb:b8:a5:83:73
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.154
     mac_addresses:
       - ec:eb:b8:a5:25:02
       - ec:eb:b8:a5:25:03
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.155
     mac_addresses:
       - ec:eb:b8:a5:55:32
       - ec:eb:b8:a5:55:33
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.156
     mac_addresses:
       - ec:eb:b8:a5:d2:32
       - ec:eb:b8:a5:d2:33
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.157
     mac_addresses:
       - ec:eb:b8:a5:c2:f2
       - ec:eb:b8:a5:c2:f3
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.158
     mac_addresses:
       - ec:eb:b8:a5:44:a2
       - ec:eb:b8:a5:44:a3
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.159
     mac_addresses:
       - ec:eb:b8:a5:15:d2
       - ec:eb:b8:a5:15:d3
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.160
     mac_addresses:
       - ec:eb:b8:a5:c3:02
       - ec:eb:b8:a5:c3:03
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.161
     mac_addresses:
       - ec:eb:b8:a5:b2:22
       - ec:eb:b8:a5:b2:23
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.162
     mac_addresses:
       - ec:eb:b8:a5:44:72
       - ec:eb:b8:a5:44:73
+    ipxe_binary: ipxe.efi
   - ip_address: 10.88.0.163
     mac_addresses:
       - ec:eb:b8:a5:a2:52
       - ec:eb:b8:a5:a2:53
+    ipxe_binary: ipxe.efi
 
 matchbox_dev:
   - ip_address: 10.88.0.248

--- a/inventories/group_vars/hosts-exp
+++ b/inventories/group_vars/hosts-exp
@@ -3,20 +3,24 @@ cfssl:
     mac_addresses:
       - fc:15:b4:22:d6:44
       - fc:15:b4:22:d6:45
+    ipxe_binary: ipxe.pxe
 
 etcd:
   - ip_address: 10.88.10.32
     mac_addresses:
       - fc:15:b4:22:07:a2
       - fc:15:b4:22:07:a3
+    ipxe_binary: ipxe.pxe
   - ip_address: 10.88.10.33
     mac_addresses:
       - fc:15:b4:22:07:a4
       - fc:15:b4:22:07:a5
+    ipxe_binary: ipxe.pxe
   - ip_address: 10.88.10.34
     mac_addresses:
       - fc:15:b4:22:07:a6
       - fc:15:b4:22:07:a7
+    ipxe_binary: ipxe.pxe
 
 env: exp
 
@@ -31,6 +35,7 @@ workers_exp:
     mac_addresses:
       - a0:1d:48:b5:1d:74
       - a0:1d:48:b5:1d:75
+
   - ip_address: 10.88.10.129
     mac_addresses:
       - a0:1d:48:b5:1e:02

--- a/inventories/group_vars/hosts-prod
+++ b/inventories/group_vars/hosts-prod
@@ -3,20 +3,24 @@ cfssl:
     mac_addresses:
       - fc:15:b4:24:af:28
       - fc:15:b4:24:af:29
+    ipxe_binary: ipxe.pxe
 
 gobgp:
   - ip_address: 10.89.0.12
     mac_addresses:
       - fc:15:b4:24:af:2c
       - fc:15:b4:24:af:2d
+    ipxe_binary: ipxe.pxe
   - ip_address: 10.89.0.13
     mac_addresses:
       - fc:15:b4:24:3f:20
       - fc:15:b4:24:3f:21
+    ipxe_binary: ipxe.pxe
   - ip_address: 10.89.0.14
     mac_addresses:
       - fc:15:b4:24:7f:a0
       - fc:15:b4:24:7f:a1
+    ipxe_binary: ipxe.pxe
 
 etcd:
   - ip_address: 10.89.0.32
@@ -59,38 +63,47 @@ workers_prod:
     mac_addresses:
       - ec:eb:b8:a5:03:b2
       - ec:eb:b8:a5:03:b3
+    ipxe_binary: ipxe.efi
   - ip_address: 10.89.0.129
     mac_addresses:
       - ec:eb:b8:a5:f3:a2
       - ec:eb:b8:a5:f3:a3
+    ipxe_binary: ipxe.efi
   - ip_address: 10.89.0.130
     mac_addresses:
       - ec:eb:b8:a5:13:12
       - ec:eb:b8:a5:13:13
+    ipxe_binary: ipxe.efi
   - ip_address: 10.89.0.131
     mac_addresses:
       - ec:eb:b8:a5:03:e2
       - ec:eb:b8:a5:03:e3
+    ipxe_binary: ipxe.efi
   - ip_address: 10.89.0.132
     mac_addresses:
       - ec:eb:b8:a5:b2:42
       - ec:eb:b8:a5:b2:43
+    ipxe_binary: ipxe.efi
   - ip_address: 10.89.0.133
     mac_addresses:
       - ec:eb:b8:a5:f3:f2
       - ec:eb:b8:a5:f3:f3
+    ipxe_binary: ipxe.efi
   - ip_address: 10.89.0.134
     mac_addresses:
       - ec:eb:b8:a5:d4:12
       - ec:eb:b8:a5:d4:13
+    ipxe_binary: ipxe.efi
   - ip_address: 10.89.0.135
     mac_addresses:
       - ec:eb:b8:a5:72:72
       - ec:eb:b8:a5:72:73
+    ipxe_binary: ipxe.efi
   - ip_address: 10.89.0.136
     mac_addresses:
       - ec:eb:b8:a5:03:a2
       - ec:eb:b8:a5:03:a3
+    ipxe_binary: ipxe.efi
 
 matchbox_prod:
   - ip_address: 10.89.0.248

--- a/roles/dhcp/handlers/main.yaml
+++ b/roles/dhcp/handlers/main.yaml
@@ -1,12 +1,12 @@
 - name: restart dhcp
   service:
-    name: "dhcp-{{ dhcp_vrf_name }}"
+    name: "dhcp-{{ dhcp_role_name }}"
     state: restarted
   become: yes
 
 - name: restart atftp
   service:
-    name: "atftp-{{ dhcp_vrf_name }}"
+    name: "atftp-{{ dhcp_role_name }}"
     state: restarted
   become: yes
 

--- a/roles/dhcp/templates/dhcp.conf.tmpl
+++ b/roles/dhcp/templates/dhcp.conf.tmpl
@@ -18,11 +18,15 @@ host cfssl-{{ loop.index }} {
   option host-name "cfssl.{{ domain_name }}";
   hardware ethernet {{ mac_address }};
   fixed-address {{ c.ip_address }};
+{% if c.ipxe_binary is defined %}
   if exists user-class and option user-class = "iPXE" {
     filename "{{ dhcp_matchbox }}";
   } else {
-    filename "ipxe.pxe";
+    filename "{{ c.ipxe_binary }}";
   }
+{% else %}
+  filename "{{ dhcp_matchbox }}";
+{% endif %}
 }
 {% endfor %}
 {% endfor %}
@@ -36,11 +40,15 @@ host gobgp-{{ gobgp_count }}-{{ loop.index }} {
   option host-name "gobgp-{{ gobgp_count }}.{{ domain_name }}";
   hardware ethernet {{ mac_address }};
   fixed-address {{ g.ip_address }};
+{% if g.ipxe_binary is defined %}
   if exists user-class and option user-class = "iPXE" {
     filename "{{ dhcp_matchbox }}";
   } else {
-    filename "ipxe.pxe";
+    filename "{{ g.ipxe_binary }}";
   }
+{% else %}
+  filename "{{ dhcp_matchbox }}";
+{% endif %}
 }
 {% endfor %}
 {% endfor %}
@@ -54,7 +62,15 @@ host etcd-{{ etcd_count }}-{{ loop.index }} {
   option host-name "etcd-{{ etcd_count }}.{{ domain_name }}";
   hardware ethernet {{ mac_address }};
   fixed-address {{ e.ip_address }};
+{% if e.ipxe_binary is defined %}
+  if exists user-class and option user-class = "iPXE" {
+    filename "{{ dhcp_matchbox }}";
+  } else {
+    filename "{{ e.ipxe_binary }}";
+  }
+{% else %}
   filename "{{ dhcp_matchbox }}";
+{% endif %}
 }
 {% endfor %}
 {% endfor %}
@@ -67,7 +83,15 @@ host master-{{ master_count }}-{{ loop.index }} {
   option host-name "master-{{ master_count }}.{{ domain_name }}";
   hardware ethernet {{ mac_address }};
   fixed-address {{ m.ip_address }};
+{% if m.ipxe_binary is defined %}
+  if exists user-class and option user-class = "iPXE" {
+    filename "{{ dhcp_matchbox }}";
+  } else {
+    filename "{{ m.ipxe_binary }}";
+  }
+{% else %}
   filename "{{ dhcp_matchbox }}";
+{% endif %}
 }
 {% endfor %}
 {% endfor %}
@@ -80,11 +104,15 @@ host worker-{{ worker_count }}-{{ loop.index }} {
   option host-name "worker-{{ worker_count }}.{{ domain_name }}";
   hardware ethernet {{ mac_address }};
   fixed-address {{ w.ip_address }};
+{% if w.ipxe_binary is defined %}
   if exists user-class and option user-class = "iPXE" {
     filename "{{ dhcp_matchbox }}";
   } else {
-    filename "ipxe.efi";
+    filename "{{ w.ipxe_binary }}";
   }
+{% else %}
+  filename "{{ dhcp_matchbox }}";
+{% endif %}
 }
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
Since we deployed an experimental cluster with the same kind of components on
different hardware types than other envs, we need to specify whether an instance
will need to look for a particular pxe boot image on our tftp server or it can
go directly to matchbox. This introduces a new variable that if defined it will
make the respective changes in dhcp config.
It also fixes handlers to restart the correct dhcp service.
No-op since the result of make dhcp-* matches the existing configurations and
ansible does not want to apply any changes.