### PR TITLE
Adding the fallback default route for DEV / filtering default route

### DIFF
--- a/roles/cumulus/templates/frr.conf.tmpl
+++ b/roles/cumulus/templates/frr.conf.tmpl
@@ -10,7 +10,7 @@ vrf dev
  ip route 10.89.0.0/16 Null0
  ip route 85.91.50.0/24 Null0
  ip route 85.91.53.0/24 Null0
- ip route 0.0.0.0/0 via 172.30.88.3 254
+ ip route 0.0.0.0/0 172.30.88.3 254
  exit-vrf
 !
 vrf prod

--- a/roles/cumulus/templates/frr.conf.tmpl
+++ b/roles/cumulus/templates/frr.conf.tmpl
@@ -10,6 +10,7 @@ vrf dev
  ip route 10.89.0.0/16 Null0
  ip route 85.91.50.0/24 Null0
  ip route 85.91.53.0/24 Null0
+ ip route 0.0.0.0/0 via 172.30.88.3 254
  exit-vrf
 !
 vrf prod
@@ -68,7 +69,9 @@ router bgp 64512 vrf dev
   neighbor 172.30.88.1 prefix-list private-dev out
   neighbor 172.30.88.2 prefix-list private-dev out
   neighbor 192.168.88.1 prefix-list public-dev out
+  neighbor 192.168.88.1 prefix-list rm-default-route in
   neighbor 192.168.88.2 prefix-list public-dev out
+  neighbor 192.168.88.2 prefix-list rm-default-route in
   maximum-paths ibgp 10
  exit-address-family
 !
@@ -108,6 +111,8 @@ ip prefix-list private-dev seq 5 permit 10.88.0.0/16
 ip prefix-list private-prod seq 5 permit 10.89.0.0/16
 ip prefix-list public-dev seq 5 permit 85.91.50.0/24
 ip prefix-list public-prod seq 5 permit 85.91.53.0/24
+ip prefix-list rm-default-route seq 5 deny 0.0.0.0/0
+ip prefix-list rm-default-route seq 10 permit 0.0.0.0/0 le 32
 !
 pbr-map pbr-dev seq 1
  match src-ip 85.91.50.0/24


### PR DESCRIPTION
The fallback route will have metric 254. It makes this route only used
when the NAT boxes are not available ( if we are rebooting / rebuilding
the whole environment). As soon as the NAT boxes become  available they will
provide default routes with metric 200 (learned via iBGP), which will
have priority over this static route (254).

Also filtering the default route learned from merit house as they are
not in use.