### PR TITLE
Adding the fallback default route for PROD / filtering default route

### DIFF
--- a/roles/cumulus/templates/frr.conf.tmpl
+++ b/roles/cumulus/templates/frr.conf.tmpl
@@ -19,6 +19,7 @@ vrf prod
  ip route 10.89.0.0/16 Null0
  ip route 85.91.50.0/24 Null0
  ip route 85.91.53.0/24 Null0
+ ip route 0.0.0.0/0 172.30.89.3 254
  exit-vrf
 !
 interface vlan188 vrf dev
@@ -103,7 +104,9 @@ router bgp 64512 vrf prod
   neighbor 172.30.89.1 prefix-list private-prod out
   neighbor 172.30.89.2 prefix-list private-prod out
   neighbor 192.168.89.1 prefix-list public-prod out
+  neighbor 192.168.89.1 prefix-list rm-default-route in
   neighbor 192.168.89.2 prefix-list public-prod out
+  neighbor 192.168.89.2 prefix-list rm-default-route in
   maximum-paths ibgp 10
  exit-address-family
 !


### PR DESCRIPTION
The fallback route will have metric 254. It makes this route only used
when the NAT boxes are not available ( if we are rebooting / rebuilding
the whole environment). As soon as the NAT boxes become  available they will
provide default routes with metric 200 (learned via iBGP), which will
have priority over this static route (254).

Also filtering the default route learned from merit house as they are
not in use.