### PR TITLE
dev: Create a policy group to be used by kube pvcs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ netapp-dev:
 	ansible-playbook -i inventories/hosts netapp_dev.yaml --diff $(check_flag) $(ARGS) --skip-tags=minio
 
 netapp-prod:
-	ansible-playbook -i inventories/hosts netapp_prod.yaml --diff $(check_flag) $(ARGS) --skip-tags=minio
+	ansible-playbook -i inventories/hosts netapp_prod.yaml --diff $(check_flag) $(ARGS) --skip-tags=minio,qos
 
 cumulus:
 	ansible-playbook -i inventories/hosts cumulus.yaml --diff $(check_flag) $(ARGS)

--- a/inventories/group_vars/netapp-dev
+++ b/inventories/group_vars/netapp-dev
@@ -10,6 +10,8 @@ vlan_parent_interface_2: e0d
 vlan_port_2: e0d-2000
 default_mtu: "9000"
 ipspace_name: "dev_ipspace"
+kube_pvc_qos_max_throughput: 15000iops
+kube_pvc_qos_min_throughput: 3000iops
 
 # cfssl
 cfssl_aggregate_list:

--- a/inventories/group_vars/netapp-exp
+++ b/inventories/group_vars/netapp-exp
@@ -8,6 +8,8 @@ node_2: system-02
 vlan_port_1: e0c-2000
 vlan_port_2: e0d-2000
 ipspace_name: "dev_ipspace"
+kube_pvc_qos_max_throughput: 15000iops
+kube_pvc_qos_min_throughput: 3000iops
 
 # cfssl
 cfssl_aggregate_list:

--- a/roles/netapp/tasks/kube.yaml
+++ b/roles/netapp/tasks/kube.yaml
@@ -255,8 +255,8 @@
   na_ontap_qos_policy_group:
     state: present
     name: "{{ env }}-pvc-fixed"
-    max_throughput: 15000iops
-    min_throughput: 3000iops
+    max_throughput: "{{ kube_pvc_qos_max_throughput }}"
+    min_throughput: "{{ kube_pvc_qos_min_throughput }}"
     is_shared: false
     vserver: "{{ env }}_kube"
     hostname: "{{ inventory_hostname }}"

--- a/roles/netapp/tasks/kube.yaml
+++ b/roles/netapp/tasks/kube.yaml
@@ -249,3 +249,17 @@
     username: "{{ netapp_username }}"
     password: "{{ netapp_password }}"
   tags: kube
+
+# Create a policy group to be used for kubernetes volumes.
+- name: create qos policy group for kube volumes
+  na_ontap_qos_policy_group:
+    state: present
+    name: "{{ env }}-pvc-fixed"
+    max_throughput: 15000iops
+    min_throughput: 3000iops
+    is_shared: false
+    vserver: "{{ env }}_kube"
+    hostname: "{{ inventory_hostname }}"
+    username: "{{ netapp_username }}"
+    password: "{{ netapp_password }}"
+  tags: kube,qos


### PR DESCRIPTION
- Create a policy with strict limits to see the impact on the behaviour on nodes
- Tag and exclude from prod runs, so we can still run netapp-prod target