### PR TITLE
Bug (new behaviour) introduced on Cumulus 4.3.0

### DIFF
--- a/roles/cumulus/templates/network-interfaces.tmpl
+++ b/roles/cumulus/templates/network-interfaces.tmpl
@@ -152,7 +152,8 @@ iface bridge
     bridge-ports peerlink bond-hp-m0-dev bond-hp-m1-dev bond-hp-m1-prod bond-hp-m2-dev bond-hp-m3-dev bond-mer-mer swp5 swp6 swp28 swp29
     bridge-vids 2 88 89 188 189 288 289 388 389 1000 1188 2000
     bridge-vlan-aware yes
-    mstpctl-treeprio 8192
+    mstpctl-treeprio 32768
+    bridge-bridgeprio 32768 
     mtu 9216
 
 #PeerLink bond for MLAG setup


### PR DESCRIPTION
Fixing the problems with MLAG introduced in 4.3.0:
https://docs.nvidia.com/networking-ethernet-software/cumulus-linux-43/Whats-New/rn/
https://support.mellanox.com/s/case/5001T00001YdbYeQAJ
After upgrading to Cumulus Linux, MLAG ports might remain down with clagctl and net show clag reporting bridge-priority-mismatch.
To work around this issue, run the sudo ifreload -a command on both peers, or configure bridge-bridgeprio to be the same value as mstpcl-treeprio on the bridge interface in the /etc/network/interfaces file, then run sudo ifreload -a.