### PR TITLE
prod-merit: Create a policy group to be used by kube pvcs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ netapp-dev:
 	ansible-playbook -i inventories/hosts netapp_dev.yaml --diff $(check_flag) $(ARGS) --skip-tags=minio
 
 netapp-prod:
-	ansible-playbook -i inventories/hosts netapp_prod.yaml --diff $(check_flag) $(ARGS) --skip-tags=minio,qos
+	ansible-playbook -i inventories/hosts netapp_prod.yaml --diff $(check_flag) $(ARGS) --skip-tags=minio
 
 cumulus-dev-prod:
 	ansible-playbook -i inventories/hosts cumulus_dev_prod.yaml --diff $(check_flag) $(ARGS)

--- a/inventories/group_vars/netapp-prod
+++ b/inventories/group_vars/netapp-prod
@@ -10,6 +10,8 @@ vlan_parent_interface_2: e1b
 vlan_port_2: e1b-1000
 default_mtu: "9000"
 ipspace_name: "prod_ipspace"
+kube_pvc_qos_max_throughput: 15000iops
+kube_pvc_qos_min_throughput: 3000iops
 
 # cfssl
 cfssl_aggregate_list:


### PR DESCRIPTION
This ensures iops limits between prod loads and should be used as a good
practice against bad actors. Haven't seen any complaints after using it on dev
for a couple of weeks.