### PR TITLE
Update node-exporter version running on cumulus

### DIFF
--- a/inventories/group_vars/cumulus
+++ b/inventories/group_vars/cumulus
@@ -1,7 +1,7 @@
 core_network_bgp_password: "{{vault_core_network_bgp_password}}"
 
 # Node exporter
-node_exporter_version: 1.0.1
+node_exporter_version: 1.3.1
 
 # ssh-key-agent
 ssh_key_agent_vesion: 1.0.12


### PR DESCRIPTION
Needs to be applied for both exp and prod environment:
`make cumulus-exp ARGS="--tags=node-exporter"`
`make cumulus-dev-prod ARGS="--tags=node-exporter"`