### PR TITLE
Use promtail to push journal logs to Loki

### DIFF
--- a/cumulus_dev_prod.yaml
+++ b/cumulus_dev_prod.yaml
@@ -14,4 +14,5 @@
     - inventories/group_vars/vault
     - inventories/group_vars/hosts-dev
     - inventories/group_vars/hosts-prod
+    - inventories/group_vars/promtail-dev-prod
   become: yes

--- a/cumulus_exp.yaml
+++ b/cumulus_exp.yaml
@@ -13,4 +13,5 @@
     - inventories/group_vars/cumulus
     - inventories/group_vars/vault
     - inventories/group_vars/hosts-exp
+    - inventories/group_vars/promtail-exp
   become: yes

--- a/inventories/group_vars/promtail-dev-prod
+++ b/inventories/group_vars/promtail-dev-prod
@@ -1,0 +1,2 @@
+promtail_version: v2.6.1
+loki_address: loki.prod.aws.uw.systems

--- a/inventories/group_vars/promtail-exp
+++ b/inventories/group_vars/promtail-exp
@@ -1,0 +1,2 @@
+promtail_version: v2.6.1
+loki_address: loki.exp-1.aws.uw.systems

--- a/roles/cumulus/files/promtail.service
+++ b/roles/cumulus/files/promtail.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Promtail service
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/bin/ip vrf exec %i /opt/bin/promtail-linux-amd64 -config.file /etc/promtail/config-promtail.yml --client.external-labels=hostname=%H
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/cumulus/handlers/main.yaml
+++ b/roles/cumulus/handlers/main.yaml
@@ -30,6 +30,12 @@
     state: restarted
   become: yes
 
+- name: restart promtail
+  service:
+    name: promtail@mgmt.service
+    state: restarted
+  become: yes
+
 - name: update timezone
   command:
     cmd: "ln -sf /usr/share/zoneinfo/Europe/London /etc/localtime"

--- a/roles/cumulus/tasks/main.yaml
+++ b/roles/cumulus/tasks/main.yaml
@@ -141,3 +141,46 @@
   notify:
     - reload network interfaces
   tags: network
+
+# Install Promtail to push journal logs to Loki. Following instructions from:
+# https://sbcode.net/grafana/install-promtail-service/
+- name: Install unzip
+  apt: pkg=unzip
+  tags: promtail
+
+- name: Download promtail
+  unarchive:
+    src: "https://github.com/grafana/loki/releases/download/{{promtail_version}}/promtail-linux-amd64.zip"
+    dest: /opt/bin
+    remote_src: yes
+  tags: promtail
+
+- name: Ensure promtail configuration directory exists
+  file:
+    path: /etc/promtail
+    state: directory
+  tags: promtail
+
+- name: Copy promtail configuration file
+  template:
+    src: config-promtail.yml.tmpl
+    dest: /etc/promtail/config-promtail.yml
+  notify:
+    - restart promtail
+  tags: promtail
+
+- name: Copy promtail systemd service unit file
+  copy:
+    src:  files/promtail.service
+    dest: /etc/systemd/system/promtail@.service
+  notify:
+    - daemon-reload
+    - restart promtail
+  tags: promtail
+
+- name: enable promtail service on management vrf
+  service:
+    name: promtail@mgmt.service
+    state: started
+    enabled: yes
+  tags: promtail

--- a/roles/cumulus/templates/config-promtail.yml.tmpl
+++ b/roles/cumulus/templates/config-promtail.yml.tmpl
@@ -1,0 +1,21 @@
+server:
+  http_listen_port: 0
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+client:
+  url: https://{{ loki_address }}/api/prom/push
+
+# https://github.com/grafana/loki/blob/main/docs/sources/clients/promtail/scraping.md#journal-scraping-linux-only
+scrape_configs:
+  - job_name: journal
+    journal:
+      json: false
+      max_age: 12h
+      labels:
+        job: cumulus-systemd-journal
+    relabel_configs:
+      - source_labels: ['__journal__systemd_unit']
+        target_label: 'unit'


### PR DESCRIPTION
- Run promtail under management vrf to push logs from journal to Loki.
- Add static job=cumulus-systemd-journal label to query for logs
- Add hostname label per cumulus instance

This pushes logs via management network (10.91/16) to the configured Loki instance. Also, there is a default metrics endpoint accessible in the same net, for example 10.91.5.131:45431/metrics. We could hopefully query that to determine the status of the promtail service and alert in case logs are not pushed through.