### PR TITLE
Pin static cluster magmt lif IP addresses to DHCP served ones

### DIFF
--- a/roles/netapp/tasks/cluster-mgmt.yaml
+++ b/roles/netapp/tasks/cluster-mgmt.yaml
@@ -24,3 +24,29 @@
     username: "{{ netapp_username }}"
     password: "{{ netapp_password }}"
   tags: cluster
+
+# We saw an incident where cluster management interfaces held different IP addresses than the ones reserved in management network DHCP.
+# Let's put the ones configured in DHCP down here to make sure we can match them for future operations
+- name: Ensure system-01_mgmt interface address
+  netapp.ontap.na_ontap_interface:
+    state: present
+    interface_name: system-01_mgmt
+    address: 10.91.5.92
+    netmask: 255.255.255.0
+    vserver: system
+    hostname: "{{ inventory_hostname }}"
+    username: "{{ netapp_username }}"
+    password: "{{ netapp_password }}"
+  tags: cluster
+
+- name: Ensure system-02_mgmt interface address
+  netapp.ontap.na_ontap_interface:
+    state: present
+    interface_name: system-02_mgmt
+    address: 10.91.5.98
+    netmask: 255.255.255.0
+    vserver: system
+    hostname: "{{ inventory_hostname }}"
+    username: "{{ netapp_username }}"
+    password: "{{ netapp_password }}"
+  tags: cluster

--- a/roles/netapp/tasks/main.yaml
+++ b/roles/netapp/tasks/main.yaml
@@ -1,5 +1,6 @@
 - name: Ensure Cluster Management Interface is properly set
   include_tasks: cluster-mgmt.yaml
+  tags: cluster
 
 - name: Create core network connectivity
   include_tasks: core.yaml


### PR DESCRIPTION
We saw an incident where cluster management interfaces held different IP addresses than the ones reserved in management network DHCP. This raised error events/logs on NetApp controllers and we were notified via a report we received from support.