### PR TITLE
Create explicit -execute make targets instead of setting DRY_RUN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,45 +2,63 @@ SHELL := /bin/bash
 
 export DOCKER_BUILDKIT=1
 
-check_flag=
-ifeq ($(DRY_RUN),true)
-check_flag := "--check"
-endif
-
 build-ipxe-binaries:
 	mkdir -p roles/dhcp/files/ipxe
 	docker build -t sys-ipxe -o roles/dhcp/files/ipxe ipxe/
 
-check-test:
-	@echo check_flat=$(check_flag)
-	@echo DRY_RUN=$(DRY_RUN)
-
-dhcp-dev:
-	ansible-playbook -i inventories/hosts dhcp_dev.yaml --diff $(check_flag) $(ARGS)
-
-dhcp-exp:
-	ansible-playbook -i inventories/hosts dhcp_exp.yaml --diff $(check_flag) $(ARGS)
-
-dhcp-prod:
-	ansible-playbook -i inventories/hosts dhcp_prod.yaml --diff $(check_flag) $(ARGS)
-
-netapp-exp:
-	ansible-playbook -i inventories/hosts netapp_exp.yaml --diff $(check_flag) --skip-tags=matchbox,cluster
-
-netapp-dev:
-	ansible-playbook -i inventories/hosts netapp_dev.yaml --diff $(check_flag) $(ARGS) --skip-tags=cluster
-
-netapp-prod:
-	ansible-playbook -i inventories/hosts netapp_prod.yaml --diff $(check_flag) $(ARGS) --skip-tags=cluster
-
-netapp-cluster:
-	ansible-playbook -i inventories/hosts netapp_prod.yaml --diff $(check_flag) $(ARGS) --tags=cluster
-
 cumulus-dev-prod:
-	ansible-playbook -i inventories/hosts cumulus_dev_prod.yaml --diff $(check_flag) $(ARGS)
+	ansible-playbook -i inventories/hosts cumulus_dev_prod.yaml --diff --check $(ARGS)
+
+cumulus-dev-prod-execute:
+	ansible-playbook -i inventories/hosts cumulus_dev_prod.yaml --diff $(ARGS)
 
 cumulus-exp:
-	ansible-playbook -i inventories/hosts cumulus_exp.yaml --diff $(check_flag) $(ARGS)
+	ansible-playbook -i inventories/hosts cumulus_exp.yaml --diff --check $(ARGS)
+
+cumulus-exp-execute:
+	ansible-playbook -i inventories/hosts cumulus_exp.yaml --diff $(ARGS)
+
+dhcp-dev:
+	ansible-playbook -i inventories/hosts dhcp_dev.yaml --diff --check $(ARGS)
+
+dhcp-dev-execute:
+	ansible-playbook -i inventories/hosts dhcp_dev.yaml --diff $(ARGS)
+
+dhcp-exp:
+	ansible-playbook -i inventories/hosts dhcp_exp.yaml --diff --check $(ARGS)
+
+dhcp-exp-execute:
+	ansible-playbook -i inventories/hosts dhcp_exp.yaml --diff $(ARGS)
+
+dhcp-prod:
+	ansible-playbook -i inventories/hosts dhcp_prod.yaml --diff --check $(ARGS)
+
+dhcp-prod-execute:
+	ansible-playbook -i inventories/hosts dhcp_prod.yaml --diff $(ARGS)
+
+netapp-cluster:
+	ansible-playbook -i inventories/hosts netapp_prod.yaml --diff --check $(ARGS) --tags=cluster
+
+netapp-cluster-execute:
+	ansible-playbook -i inventories/hosts netapp_prod.yaml --diff $(ARGS) --tags=cluster
+
+netapp-dev:
+	ansible-playbook -i inventories/hosts netapp_dev.yaml --diff --check $(ARGS) --skip-tags=cluster
+
+netapp-dev-execute:
+	ansible-playbook -i inventories/hosts netapp_dev.yaml --diff $(ARGS) --skip-tags=cluster
+
+netapp-exp:
+	ansible-playbook -i inventories/hosts netapp_exp.yaml --diff --check $(ARGS) --skip-tags=matchbox,cluster
+
+netapp-exp-execute:
+	ansible-playbook -i inventories/hosts netapp_exp.yaml --diff $(ARGS) --skip-tags=matchbox,cluster
+
+netapp-prod:
+	ansible-playbook -i inventories/hosts netapp_prod.yaml --diff --check $(ARGS) --skip-tags=cluster
+
+netapp-prod-execute:
+	ansible-playbook -i inventories/hosts netapp_prod.yaml --diff $(ARGS) --skip-tags=cluster
 
 netapp-collections-install:
 	ansible-galaxy collection install netapp.ontap


### PR DESCRIPTION
Change the make targets behaviour so that they result in a dry run unless suffixed with -execute. That should replace setting DRY_RUN env variable with a more explicit way of knowing whem `make` is actively going to change remote config.