### PR TITLE
Comment out Cumulus apt update commands

### DIFF
--- a/roles/cumulus/tasks/main.yaml
+++ b/roles/cumulus/tasks/main.yaml
@@ -25,7 +25,7 @@
 - name: Update repositories cache and install certificates package
   apt:
     name: ca-certificates
-    update_cache: yes
+    #update_cache: yes
   tags: certs
 
 - name: Ensure /opt/bin directory exists

--- a/roles/dhcp/tasks/main.yaml
+++ b/roles/dhcp/tasks/main.yaml
@@ -2,7 +2,7 @@
   apt:
     name: isc-dhcp-server
     state: present
-    update_cache: yes
+    #update_cache: yes
   tags: dhcp
 
 - name: Create /etc/dhcp-{{ dhcp_role_name }}
@@ -39,7 +39,7 @@
   apt:
     name: atftpd
     state: present
-    update_cache: yes
+    #update_cache: yes
   tags: tftp
 
 - name: Create /etc/tftpboot-{{ dhcp_role_name }}


### PR DESCRIPTION
Temporary workaround for the failing sudo apt update commands on Cumulus instances