### PR TITLE
Document maximum ansible version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ terraform based model.
 
 # Requirements
 
-- ansible >=2.7 local setup
+- ansible (>=2.7 and <=10.7) local setup (eg: `pipx install --include-deps ansible==10.7.0`)
 - `system` strongbox key
 - `make netapp-collections-install` to install netapp.ontap collections for ansible
 - `pip install netapp-lib requests` is also needed by ansible netapp modules to run


### PR DESCRIPTION
Ansible 11.0 uses ansible-core 2.18, which requires python 2.8 to work. Cumulus OS is based on debian buster, which only packages python up to 2.7.

So for all the cumulus targets, the maximum ansible version is 11.7